### PR TITLE
fix: YAML frontmatter 누락된 22개 스킬에 name/description 추가

### DIFF
--- a/api-design/SKILL.md
+++ b/api-design/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: api-design
+description: >-
+  REST API design principles including URL design, HTTP methods, status codes,
+  pagination, versioning, security, and OpenAPI documentation.
+  Use when designing or implementing REST APIs.
+---
+
 # REST API Design Rules
 
 ## 1. URL Design

--- a/chaos-engineering/SKILL.md
+++ b/chaos-engineering/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: chaos-engineering
+description: >-
+  Chaos engineering principles and practices for building resilient systems.
+  Use when designing reliability testing, failure injection experiments, or game days.
+---
+
 # Skill: Chaos Engineering
 
 **Source**: Release It! Second Edition - Michael Nygard (Chapter 17)

--- a/clean-architecture/SKILL.md
+++ b/clean-architecture/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: clean-architecture
+description: >-
+  Clean Architecture and Hexagonal Architecture (Ports & Adapters) patterns.
+  Use when designing layered architecture, defining port/adapter boundaries,
+  or structuring domain-centric applications.
+---
+
 # Clean Architecture / Hexagonal Architecture Rules
 
 ## 1. Architecture Principles

--- a/concurrency/SKILL.md
+++ b/concurrency/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: concurrency
+description: >-
+  JVM concurrency rules including thread safety, synchronization tools,
+  Executor framework, CompletableFuture, Kotlin coroutines, and virtual threads.
+  Use when writing concurrent or parallel code.
+---
+
 # JVM Concurrency Rules
 
 ## 1. Thread Safety Principles

--- a/ddd/SKILL.md
+++ b/ddd/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: ddd
+description: >-
+  Domain-Driven Design patterns including entities, value objects, aggregates,
+  repositories, domain services, domain events, and bounded contexts.
+  Use when designing domain models or implementing business logic.
+---
+
 # Domain-Driven Design (DDD) Skill
 
 Domain-Driven Design patterns and practices for building complex software systems. Use when designing domain models, implementing business logic, or structuring domain-centric applications.

--- a/distributed-systems/SKILL.md
+++ b/distributed-systems/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: distributed-systems
+description: >-
+  Distributed systems design patterns including data replication, partitioning,
+  distributed time, cluster management, and network communication.
+  Use when designing or implementing distributed systems.
+---
+
 # Distributed Systems Patterns
 
 30 patterns for building reliable distributed systems. Use when designing or implementing distributed databases, messaging systems, or microservices architectures.

--- a/dockerfile/SKILL.md
+++ b/dockerfile/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: dockerfile
+description: >-
+  Dockerfile best practices including multi-stage builds, layer caching,
+  security, and JVM/Spring Boot containerization patterns.
+  Use when writing or reviewing Dockerfiles.
+---
+
 # Dockerfile Rules
 
 ## 1. Multi-Stage Build Pattern

--- a/jvm-performance/SKILL.md
+++ b/jvm-performance/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: jvm-performance
+description: >-
+  JVM performance tuning including garbage collection algorithms, GC selection,
+  heap analysis, profiling tools, and cloud-native considerations.
+  Use when diagnosing performance issues or tuning JVM parameters.
+---
+
 # JVM Performance Optimization
 
 Java Virtual Machine performance tuning, garbage collection, and profiling techniques. Use when diagnosing performance issues, tuning JVM parameters, or optimizing Java applications.

--- a/k8s-autoscaling/SKILL.md
+++ b/k8s-autoscaling/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: k8s-autoscaling
+description: >-
+  Kubernetes autoscaling guide covering KEDA, Knative, event-driven scaling,
+  and scale-to-zero patterns.
+  Use when configuring autoscaling on Kubernetes.
+---
+
 
 # Kubernetes Autoscaling Guide
 

--- a/k8s-providers/SKILL.md
+++ b/k8s-providers/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: k8s-providers
+description: >-
+  Managed Kubernetes providers comparison and best practices for AWS EKS,
+  Azure AKS, and GCP GKE including networking, storage, security, and upgrades.
+  Use when working with managed Kubernetes services.
+---
+
 # Managed Kubernetes Providers Guide
 
 ## 1. Provider Comparison

--- a/karpenter-providers/SKILL.md
+++ b/karpenter-providers/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: karpenter-providers
+description: >-
+  Karpenter cloud provider configurations for AWS EC2NodeClass, Azure AKSNodeClass,
+  and GCP GKENodeClass including spot instances, monitoring, and troubleshooting.
+  Use when configuring Karpenter for specific cloud providers.
+---
+
 
 # Karpenter Cloud Providers Guide
 

--- a/microservices/SKILL.md
+++ b/microservices/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: microservices
+description: >-
+  Microservices architecture patterns including service decomposition, communication,
+  API gateway, Saga, CQRS, data management, and fault isolation.
+  Use when designing or reviewing microservice architectures.
+---
+
 # Microservices Architecture Pattern Rules
 
 ## 1. Service Decomposition Principles

--- a/object-oriented-design/SKILL.md
+++ b/object-oriented-design/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: object-oriented-design
+description: >-
+  Object-oriented design principles (SOLID) with practical examples.
+  Use when designing class hierarchies, applying SOLID principles,
+  or reviewing object-oriented design.
+---
+
 # Object-Oriented Design Principles (SOLID Advanced)
 
 ## 1. SRP (Single Responsibility Principle)

--- a/refactoring/SKILL.md
+++ b/refactoring/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: refactoring
+description: >-
+  Refactoring techniques including code smell identification, extract/inline methods,
+  conditional simplification, and data organization.
+  Use when refactoring code or identifying code smells.
+---
+
 # Refactoring Rules
 
 ## 1. Refactoring Principles

--- a/spring-caching/SKILL.md
+++ b/spring-caching/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: spring-caching
+description: >-
+  Spring Boot caching implementation patterns including Caffeine, Redis,
+  @Cacheable, and event-based invalidation.
+  Use when writing Spring Boot cache code.
+---
+
 # Spring Boot Caching Rules
 
 일반적인 캐싱 원칙(캐시 전략 선택, TTL 설계, 무효화 패턴, 안티패턴)은 `caching.md` 참조.

--- a/spring-error-handling/SKILL.md
+++ b/spring-error-handling/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: spring-error-handling
+description: >-
+  Spring Boot error handling patterns including @ControllerAdvice,
+  BusinessException, ErrorCode enum, and error response implementation.
+  Use when writing Spring Boot exception handling code.
+---
+
 # Spring Boot Error Handling Rules
 
 일반적인 에러 처리 원칙(예외 계층, 에러 응답 포맷, 계층별 가이드라인, 외부 API 에러 처리, 안티패턴)은 `error-handling.md` 참조.

--- a/spring-http-client/SKILL.md
+++ b/spring-http-client/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: spring-http-client
+description: >-
+  Spring Boot API client patterns including RestClient, Spring Retry,
+  Resilience4j circuit breaker, and response DTO mapping.
+  Use when writing Spring Boot HTTP client code.
+---
+
 # Spring Boot API Client Rules
 
 일반적인 외부 API 클라이언트 원칙(타임아웃 전략, 에러 분류, 재시도 전략, Circuit Breaker 파라미터, 응답 매핑 원칙, 안티패턴)은 `http-client.md` 참조.

--- a/spring-monitoring/SKILL.md
+++ b/spring-monitoring/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: spring-monitoring
+description: >-
+  Spring Boot monitoring patterns including Actuator, Micrometer custom metrics,
+  distributed tracing, and health check implementation.
+  Use when implementing Spring Boot observability.
+---
+
 # Spring Boot Monitoring Rules
 
 일반적인 모니터링 원칙(옵저버빌리티 3대 요소, 메트릭 유형/명명, 핵심 메트릭, 알림 규칙, 헬스체크 개념, 안티패턴)은 `monitoring.md` 참조.

--- a/spring-security/SKILL.md
+++ b/spring-security/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: spring-security
+description: >-
+  Spring Boot security implementation including SecurityFilterChain,
+  Bean Validation, CORS configuration, and rate limiting.
+  Use when writing Spring Security configuration.
+---
+
 # Spring Boot Security Rules
 
 일반적인 보안 원칙(입력 검증, 인증/인가, CORS, 보안 헤더, Rate Limiting, 응답 필터링, 시크릿 관리, 안티패턴)은 `security.md` 참조.

--- a/system-design/SKILL.md
+++ b/system-design/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: system-design
+description: >-
+  Large-scale system design patterns including database architecture, caching,
+  CDN, stateless design, message queues, consistent hashing, and rate limiting.
+  Use when designing scalable system architectures.
+---
+
 # System Design Interview Patterns
 
 Large-scale system design principles and patterns. Use when designing scalable architectures, preparing for system design interviews, or evaluating system architecture.

--- a/system-stability-patterns/SKILL.md
+++ b/system-stability-patterns/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: system-stability-patterns
+description: >-
+  System stability anti-patterns and patterns including circuit breaker,
+  bulkhead, backpressure, load shedding, and timeout strategies.
+  Use when reviewing system stability or designing fault-tolerant systems.
+---
+
 # Skill: System Stability Patterns
 
 **Source**: Release It! Second Edition - Michael Nygard

--- a/technical-documentation/SKILL.md
+++ b/technical-documentation/SKILL.md
@@ -1,3 +1,11 @@
+---
+name: technical-documentation
+description: >-
+  Technical documentation guide covering writing principles, user research,
+  deployment process, and quality measurement.
+  Use when writing or reviewing technical documentation.
+---
+
 # Technical Documentation Guide
 
 Comprehensive guide for writing, researching, deploying, and measuring technical documentation quality.


### PR DESCRIPTION
## Summary

- frontmatter(`name`, `description`)가 누락된 22개 스킬에 YAML frontmatter 추가
- 에이전트가 스킬 용도를 판단하여 자동 로딩할 수 있도록 `description` 작성

## 대상 스킬 (22개)

`api-design`, `chaos-engineering`, `clean-architecture`, `concurrency`, `ddd`, `distributed-systems`, `dockerfile`, `jvm-performance`, `k8s-autoscaling`, `k8s-providers`, `karpenter-providers`, `microservices`, `object-oriented-design`, `refactoring`, `spring-caching`, `spring-error-handling`, `spring-http-client`, `spring-monitoring`, `spring-security`, `system-design`, `system-stability-patterns`, `technical-documentation`

## 변경 내용

각 SKILL.md 파일 상단에 아래 형식의 frontmatter를 추가:

```yaml
---
name: <skill-name>
description: >-
  <스킬 설명>
---
```

## Test plan

- [ ] 모든 62개 스킬에 `name`과 `description`이 존재하는지 확인
- [ ] frontmatter YAML 형식이 올바른지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)