### PR TITLE
docs: 내용 부실 스킬 4개 보완

### DIFF
--- a/caching/SKILL.md
+++ b/caching/SKILL.md
@@ -24,11 +24,25 @@ description: >-
 
 ### Cache Placement
 
-| Type          | Latency | Scope           |
-| ------------- | ------- | --------------- |
-| Local (L1)    | ~1ms    | Single instance |
-| Distributed   | ~5ms    | All instances   |
-| HTTP cache    | Varies  | Client/CDN      |
+| Type          | Latency | Scope           | Use Case                      |
+| ------------- | ------- | --------------- | ----------------------------- |
+| Local (L1)    | ~1ms    | Single instance | Hot data, high read frequency |
+| Distributed   | ~5ms    | All instances   | Shared state, session data    |
+| HTTP cache    | Varies  | Client/CDN      | Static assets, public APIs    |
+| Two-level     | ~1ms+   | L1 + distributed| Hot data across instances     |
+
+### Two-Level Cache Pattern
+
+```text
+Request → L1 (local) → L2 (distributed) → Data source
+             ↑ miss         ↑ miss              │
+             └──────────────┴───── populate ─────┘
+```
+
+- L1 (Caffeine, Guava): sub-millisecond, per-instance
+- L2 (Redis, Memcached): single-digit ms, shared
+- On L1 miss, check L2 before hitting the data source
+- Invalidate both levels on writes
 
 ---
 
@@ -43,6 +57,8 @@ description: >-
 | Search results          | 5-10 minutes     | Freshness matters           |
 | API rate limit counters | 1 minute window  | Must be accurate            |
 | Session data            | 30 min - 2 hours | Balance UX and security     |
+| Product catalog         | 1-6 hours        | Changes infrequently        |
+| Dashboard aggregations  | 1-5 minutes      | Near-real-time acceptable   |
 
 ### TTL Rules
 
@@ -52,17 +68,69 @@ description: >-
 - Use explicit eviction on writes in addition to TTL
 - Consider TTL jitter to avoid cache stampede
 
+### TTL Jitter
+
+```text
+Effective TTL = base_ttl + random(0, jitter_range)
+
+Example: base 10min, jitter 2min → actual TTL between 10-12min
+```
+
+Without jitter, cached entries expire simultaneously, causing a thundering herd to the data source.
+
 ---
 
-## 3. Cache Invalidation Patterns
+## 3. Cache Key Design
+
+### Key Structure
+
+```text
+<namespace>:<entity>:<identifier>[:<variant>]
+
+Examples:
+  user:profile:12345
+  product:detail:SKU-001:v2
+  search:results:shoes:page=1:size=20
+```
+
+### Key Design Rules
+
+| Rule                        | Reason                                  |
+| --------------------------- | --------------------------------------- |
+| Include type prefix         | Prevents key collisions across entities |
+| Include version if needed   | Supports cache-friendly schema changes  |
+| Keep keys short             | Saves memory in distributed cache       |
+| Avoid user input in keys    | Prevents cache poisoning attacks        |
+| Normalize key components    | Ensures consistent lookups              |
+
+---
+
+## 4. Cache Invalidation Patterns
 
 ### Write-Through
 
 Update the cache entry simultaneously when writing to the data store. Ensures cache is always consistent but adds write latency.
 
-### Evict on Write
+```text
+Write request → Update DB → Update cache → Return
+```
+
+### Evict on Write (Cache-Aside)
 
 Evict the cache entry on write and let the next read repopulate it. Simpler to implement and avoids stale data from failed cache updates.
+
+```text
+Write: Write request → Update DB → Evict cache → Return
+Read:  Read request → Cache miss → Read DB → Populate cache → Return
+```
+
+### Write-Behind (Write-Back)
+
+Write to cache first, then asynchronously persist to the data store. Lowest write latency but risks data loss.
+
+```text
+Write request → Update cache → Return (async persist to DB)
+```
 
 ### Event-Based Invalidation
 
@@ -77,7 +145,38 @@ Invalidate cache entries via events (message queue, application events) for cros
 
 ---
 
-## 4. Anti-Patterns
+## 5. Cache Stampede Prevention
+
+A cache stampede occurs when many requests simultaneously miss the cache and hit the data source.
+
+### Prevention Strategies
+
+| Strategy             | Description                                     | Trade-off                |
+| -------------------- | ----------------------------------------------- | ------------------------ |
+| Mutex/lock           | Only one request rebuilds, others wait           | Adds latency for waiters |
+| Probabilistic expiry | Refresh before TTL expires with some probability | Slightly stale data      |
+| Background refresh   | Async refresh before expiry                      | More complexity          |
+| Stale-while-revalidate | Serve stale, refresh in background            | Brief staleness window   |
+
+---
+
+## 6. Cache Warming
+
+### When to Warm
+
+- Application startup with predictable hot data
+- After cache flush or failover
+- Before traffic spike (scheduled events, promotions)
+
+### Warming Rules
+
+- Warm only high-frequency keys — not the entire dataset
+- Stagger warming to avoid overwhelming the data source
+- Set shorter TTL for warmed entries if staleness risk is high
+
+---
+
+## 7. Anti-Patterns
 
 - Caching without TTL (memory leak risk)
 - Caching mutable objects (caller modifies cached reference)
@@ -87,3 +186,5 @@ Invalidate cache entries via events (message queue, application events) for cros
 - Over-caching (caching everything "just in case")
 - No monitoring of cache hit/miss rates
 - Using distributed cache for data that only needs local caching
+- Cache-aside without stampede protection on hot keys
+- Storing large objects (> 1MB) in distributed cache without compression

--- a/database/SKILL.md
+++ b/database/SKILL.md
@@ -38,6 +38,24 @@ V4__add_status_column_to_orders.sql
 - Include both schema and essential seed data in migrations
 - Test migrations against a copy of production data before applying
 
+### Migration Safety Checklist
+
+| Operation             | Risk   | Precaution                                     |
+| --------------------- | ------ | ---------------------------------------------- |
+| Add column (nullable) | Low    | Safe — no data rewrite needed                  |
+| Add column (NOT NULL) | Medium | Requires default value or backfill             |
+| Drop column           | High   | Ensure no application code references it       |
+| Rename column         | High   | Use two-phase: add new → migrate → drop old    |
+| Add index             | Medium | Use `CONCURRENTLY` on large tables (Postgres)  |
+| Drop table            | High   | Verify no foreign keys or application refs     |
+| Change column type    | High   | May require full table rewrite                 |
+
+### Rollback Strategy
+
+- Write corresponding rollback scripts for each migration
+- For irreversible changes (drop column), document the decision and ensure backups exist
+- Test rollback scripts in staging before production deployment
+
 ---
 
 ## 2. Query Performance
@@ -49,12 +67,62 @@ V4__add_status_column_to_orders.sql
 - Avoid over-indexing — each index slows down writes
 - Monitor slow query logs to identify missing indexes
 
+### Composite Index Column Order
+
+```text
+Index (a, b, c) supports:
+  ✅ WHERE a = ?
+  ✅ WHERE a = ? AND b = ?
+  ✅ WHERE a = ? AND b = ? AND c = ?
+  ✅ WHERE a = ? ORDER BY b
+  ❌ WHERE b = ?           (leftmost prefix not satisfied)
+  ❌ WHERE b = ? AND c = ? (leftmost prefix not satisfied)
+```
+
+- Place equality columns before range columns
+- Place high-selectivity columns first
+
 ### Query Best Practices
 
 - Use pagination for list queries — never fetch unbounded result sets
 - Avoid `SELECT *` — specify only needed columns for large tables
 - Use `EXISTS` instead of `COUNT` for existence checks
 - Avoid complex subqueries — prefer `JOIN` for readability and performance
+
+### Pagination Patterns
+
+| Pattern        | Pros                     | Cons                       | Best For            |
+| -------------- | ------------------------ | -------------------------- | ------------------- |
+| Offset-based   | Simple, page navigation  | Slow on large offsets      | Small datasets      |
+| Cursor-based   | Consistent, fast         | No random page access      | Large datasets      |
+| Keyset-based   | Fast, no offset overhead | Requires unique sort key   | Fixed sort order    |
+
+```sql
+-- Offset-based (simple but slow for large offsets)
+SELECT * FROM users ORDER BY id LIMIT 20 OFFSET 100;
+
+-- Cursor-based (fast and consistent)
+SELECT * FROM users WHERE id > :last_seen_id ORDER BY id LIMIT 20;
+```
+
+### N+1 Query Detection
+
+```text
+Symptom: N similar queries in logs for a single operation
+
+-- 1 query to fetch users
+SELECT * FROM users WHERE status = 'ACTIVE';
+
+-- N queries to fetch each user's orders (BAD)
+SELECT * FROM orders WHERE user_id = 1;
+SELECT * FROM orders WHERE user_id = 2;
+...
+
+-- Fix: single join query
+SELECT u.*, o.* FROM users u
+LEFT JOIN orders o ON u.id = o.user_id
+WHERE u.status = 'ACTIVE';
+```
 
 ---
 
@@ -78,9 +146,50 @@ V4__add_status_column_to_orders.sql
 3. Write result (separate transaction)
 ```
 
+### Isolation Levels
+
+| Level            | Dirty Read | Non-Repeatable Read | Phantom Read | Use Case                   |
+| ---------------- | ---------- | ------------------- | ------------ | -------------------------- |
+| READ UNCOMMITTED | Possible   | Possible            | Possible     | Almost never appropriate   |
+| READ COMMITTED   | No         | Possible            | Possible     | Default for most databases |
+| REPEATABLE READ  | No         | No                  | Possible     | Financial calculations     |
+| SERIALIZABLE     | No         | No                  | No           | Critical consistency needs |
+
+- Default to database's built-in isolation level (usually READ COMMITTED)
+- Only increase isolation when business logic requires stronger guarantees
+- Higher isolation = more locking = lower concurrency
+
+### Deadlock Prevention
+
+- Always acquire locks in a consistent, predictable order
+- Keep lock scope as small as possible
+- Set statement/query timeouts to avoid indefinite waits
+- Log and monitor deadlock occurrences
+
 ---
 
-## 4. Anti-Patterns
+## 4. Data Integrity
+
+### Constraints
+
+| Constraint    | Purpose                        | When to Use                          |
+| ------------- | ------------------------------ | ------------------------------------ |
+| PRIMARY KEY   | Unique row identity            | Every table                          |
+| FOREIGN KEY   | Referential integrity          | Related tables                       |
+| UNIQUE        | Prevent duplicate values       | Business-unique columns (email, etc.)|
+| NOT NULL      | Prevent missing values         | Required fields                      |
+| CHECK         | Validate value range/format    | Enum-like or bounded values          |
+| DEFAULT       | Provide fallback value         | Optional fields with sensible default|
+
+### Rules
+
+- Enforce data integrity at the database level, not just application level
+- Application validations may be bypassed; database constraints are the last line of defense
+- Use `ON DELETE CASCADE` cautiously — prefer explicit application-level deletion
+
+---
+
+## 5. Anti-Patterns
 
 - Unbounded queries without pagination
 - `SELECT *` on large tables
@@ -89,3 +198,7 @@ V4__add_status_column_to_orders.sql
 - Missing indexes on frequently queried columns
 - Modifying applied migration files
 - No slow query monitoring
+- Using database as a message queue
+- Storing large blobs in relational tables without evaluating object storage
+- Missing foreign key constraints on related tables
+- Using `FLOAT`/`DOUBLE` for monetary values (use `DECIMAL`/`NUMERIC`)

--- a/pdf-handling/SKILL.md
+++ b/pdf-handling/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   PDF file reading and processing rules.
   Use when analyzing PDF files or extracting content from them.
 ---
+
 # PDF File Handling Rules
 
 ## Conversion Procedure
@@ -38,3 +39,64 @@ description: >-
 - If the Read tool fails due to file size, always fall back to `pdftoppm`
 - Estimate the PDF page offset by comparing displayed page numbers with actual PDF page numbers
 - When searching for specific content, use the table of contents to calculate target page numbers rather than scanning sequentially
+
+## Command Reference
+
+### pdftoppm
+
+```bash
+# Convert specific page range to PNG
+pdftoppm -png -f <first> -l <last> input.pdf /tmp/output_prefix
+
+# Example: convert pages 1-5
+pdftoppm -png -f 1 -l 5 input.pdf /tmp/project_toc
+
+# Higher resolution (default 150 DPI, use 300 for small text)
+pdftoppm -png -r 300 -f 1 -l 1 input.pdf /tmp/high_res
+```
+
+### pdfinfo
+
+```bash
+# Check page count, file size, and metadata
+pdfinfo input.pdf
+```
+
+### pdftotext
+
+```bash
+# Extract text from specific pages (preserve layout)
+pdftotext -f 1 -l 5 -layout input.pdf /tmp/output.txt
+
+# Extract all text
+pdftotext input.pdf /tmp/output.txt
+```
+
+## Workflow
+
+### Standard PDF Analysis Procedure
+
+```text
+1. Run pdfinfo to check document metadata (page count, size)
+2. Convert table of contents pages with pdftoppm to understand structure
+3. Selectively convert only the pages needed for the task
+4. Analyze images or extract text with pdftotext
+5. Clean up temporary files in /tmp/
+```
+
+### Page Number Offset Handling
+
+The actual PDF page number and the printed page number in the document may differ.
+
+| Situation                      | Example                           | Resolution                          |
+| ------------------------------ | --------------------------------- | ----------------------------------- |
+| Cover/preface pages present    | Document "page 1" is PDF page 3  | Apply offset +2                     |
+| Roman numeral pages            | i, ii, iii, ...                   | Cross-reference with table of contents |
+| Appendix with separate numbers | A-1, A-2, ...                     | Calculate PDF page from table of contents |
+
+## Anti-Patterns
+
+- Converting the entire PDF at once (memory/disk exhaustion on large files)
+- Not cleaning up temporary PNG files after extraction
+- Converting pages without verifying the page number offset
+- Using image conversion when direct text extraction (`pdftotext`) is sufficient

--- a/spring-troubleshooting/SKILL.md
+++ b/spring-troubleshooting/SKILL.md
@@ -20,13 +20,45 @@ description: >-
 
 ### Common Causes and Fixes
 
-| Error                                         | Cause                          | Fix                                                 |
-| --------------------------------------------- | ------------------------------ | --------------------------------------------------- |
-| `UnsatisfiedDependencyException`              | Missing bean or circular dep   | Check `@Component` scan path, break circular dep    |
-| `HikariPool-1 - Connection is not available`  | DB unreachable or creds wrong  | Verify `spring.datasource.*` config and network     |
-| `Port already in use`                         | Another process on same port   | Kill the process or change `server.port`            |
-| `NoSuchBeanDefinitionException`               | Bean not registered            | Check package scan, `@Configuration` class          |
-| `Failed to configure a DataSource`            | Missing DB driver or URL       | Add `runtimeOnly` driver dep, set datasource URL    |
+| Error                                        | Cause                        | Fix                                              |
+| -------------------------------------------- | ---------------------------- | ------------------------------------------------ |
+| `UnsatisfiedDependencyException`             | Missing bean or circular dep | Check `@Component` scan path, break circular dep |
+| `HikariPool-1 - Connection is not available` | DB unreachable or creds wrong| Verify `spring.datasource.*` config and network  |
+| `Port already in use`                        | Another process on same port | Kill the process or change `server.port`         |
+| `NoSuchBeanDefinitionException`              | Bean not registered          | Check package scan, `@Configuration` class       |
+| `Failed to configure a DataSource`           | Missing DB driver or URL     | Add `runtimeOnly` driver dep, set datasource URL |
+
+### Circular Dependency Resolution
+
+```kotlin
+// Bad: A depends on B, B depends on A
+@Service
+class ServiceA(private val serviceB: ServiceB)
+
+@Service
+class ServiceB(private val serviceA: ServiceA) // Circular!
+
+// Fix 1: Use @Lazy on one side
+@Service
+class ServiceB(@Lazy private val serviceA: ServiceA)
+
+// Fix 2: Extract shared logic into a third service
+@Service
+class SharedService  // Contains the shared logic
+```
+
+### Bean Conflict Resolution
+
+```kotlin
+// Multiple beans of same type
+// Fix: Use @Primary or @Qualifier
+@Bean
+@Primary
+fun primaryDataSource(): DataSource = ...
+
+@Bean("secondaryDs")
+fun secondaryDataSource(): DataSource = ...
+```
 
 ---
 
@@ -34,10 +66,13 @@ description: >-
 
 ### OOM Types
 
-1. `Java heap space` → heap exhaustion
-2. `Metaspace` → too many classes loaded
-3. `GC overhead limit exceeded` → spending 98%+ time in GC
-4. `unable to create new native thread` → thread limit reached
+| Type                            | Cause                        | Investigation                           |
+| ------------------------------- | ---------------------------- | --------------------------------------- |
+| `Java heap space`               | Heap exhaustion              | Heap dump analysis                      |
+| `Metaspace`                     | Too many classes loaded      | Check dynamic class generation          |
+| `GC overhead limit exceeded`    | 98%+ time spent in GC        | Heap dump + GC log analysis             |
+| `unable to create native thread`| Thread limit reached         | Check thread count, ulimit settings     |
+| `Direct buffer memory`          | NIO buffer exhaustion        | Check `-XX:MaxDirectMemorySize`         |
 
 ### Investigation Commands
 
@@ -51,12 +86,72 @@ jcmd 1 VM.flags
 # Force heap dump from running process
 jcmd 1 GC.heap_dump /tmp/heapdump.hprof
 
-# Analyze heap dump with MAT or VisualVM
+# Check GC activity
+jstat -gcutil <pid> 1000 10
+
+# Check thread count
+jcmd 1 Thread.print | grep -c "tid="
+```
+
+### Common OOM Causes
+
+| Cause                       | Symptom                          | Fix                                      |
+| --------------------------- | -------------------------------- | ---------------------------------------- |
+| Memory leak (unclosed)      | Gradual memory increase          | Fix resource cleanup, try-with-resources |
+| Unbounded collection growth | Spike after specific request     | Add pagination, limit collection size    |
+| Too many threads            | `unable to create native thread` | Use thread pools, reduce parallelism     |
+| Container limit too low     | Immediate OOM on startup         | Increase container memory limit          |
+| `MaxRAMPercentage` too high | No room for non-heap             | Set to 75% or lower                      |
+
+### Container Memory Sizing
+
+```bash
+# Recommended JVM flags for containers
+-XX:MaxRAMPercentage=75.0     # Leave 25% for non-heap
+-XX:InitialRAMPercentage=50.0
+
+# Check effective heap size inside container
+jcmd 1 GC.heap_info
 ```
 
 ---
 
-## 3. Spring-Specific Slow API Response
+## 3. HikariCP Connection Pool Issues
+
+### Diagnosis
+
+```bash
+# Enable HikariCP debug logging
+logging.level.com.zaxxer.hikari=DEBUG
+logging.level.com.zaxxer.hikari.pool.HikariPool=DEBUG
+```
+
+### Common Issues
+
+| Symptom                              | Cause                            | Fix                                       |
+| ------------------------------------ | -------------------------------- | ----------------------------------------- |
+| `Connection is not available`        | Pool exhausted                   | Increase `maximum-pool-size` or fix leaks |
+| `Connection timed out after 30000ms` | Slow queries holding connections | Optimize queries, add statement timeout   |
+| `Connection reset`                   | Idle conn killed by DB/proxy     | Set `max-lifetime` below DB timeout       |
+| Connections not returned             | Missing `@Transactional` close   | Ensure all connections are properly closed |
+
+### Recommended Configuration
+
+```yaml
+spring:
+  datasource:
+    hikari:
+      maximum-pool-size: 10       # Default: 10
+      minimum-idle: 5             # Default: same as maximum
+      connection-timeout: 30000   # 30s (default)
+      idle-timeout: 600000        # 10min
+      max-lifetime: 1800000       # 30min (must be < DB wait_timeout)
+      leak-detection-threshold: 60000  # 60s — logs warning for leaked connections
+```
+
+---
+
+## 4. Spring-Specific Slow API Response
 
 ### Profiling Approach
 
@@ -76,9 +171,58 @@ log.info("Operation completed", mapOf("durationMs" to duration))
 | No caching                                | Same query repeated          | Add `@Cacheable` or Redis cache    |
 | HikariCP pool exhaustion                  | Pool warning in logs         | Increase pool size or optimize     |
 | Missing `@Transactional(readOnly = true)` | Unnecessary write locks      | Add readOnly for read operations   |
+| Lazy loading outside session              | `LazyInitializationException`| Use fetch join or DTO projection   |
+| Large response serialization              | High CPU during response     | Use pagination, field selection    |
+
+### SQL Logging Configuration
+
+```yaml
+# Development — show SQL with parameters
+spring:
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE
+```
+
+---
+
+## 5. Actuator-Based Diagnostics
+
+### Useful Actuator Endpoints
+
+| Endpoint          | Purpose                               |
+| ----------------- | ------------------------------------- |
+| `/actuator/health`| Application and dependency health     |
+| `/actuator/metrics`| JVM, HikariCP, HTTP metrics          |
+| `/actuator/env`   | Effective configuration values        |
+| `/actuator/beans` | All registered beans                  |
+| `/actuator/conditions` | Auto-configuration report        |
+
+### Key Metrics to Check
+
+```bash
+# HikariCP pool status
+GET /actuator/metrics/hikaricp.connections.active
+GET /actuator/metrics/hikaricp.connections.pending
+
+# JVM memory
+GET /actuator/metrics/jvm.memory.used
+GET /actuator/metrics/jvm.gc.pause
+
+# HTTP request latency
+GET /actuator/metrics/http.server.requests
+```
 
 ---
 
 ## Related Skills
 
-- **troubleshooting** — Framework-agnostic debugging patterns (slow APIs, deployment rollback, connection issues)
+- `troubleshooting` — Framework-agnostic debugging patterns (slow APIs, deployment rollback, connection issues)
+- `jvm-performance` — GC tuning, profiling tools, heap dump analysis
+- `spring-config` — Configuration properties, profile management, HikariCP setup


### PR DESCRIPTION
## Summary

다른 스킬 대비 내용이 부족했던 4개 스킬의 가이드라인을 보강합니다.

## 변경 내용

| 스킬 | 변경 전 | 변경 후 | 추가된 내용 |
|------|---------|---------|------------|
| `pdf-handling` | 40줄 | 102줄 | Command reference, workflow, page offset handling |
| `spring-troubleshooting` | 84줄 | 228줄 | Circular dep, HikariCP, OOM table, Actuator diagnostics |
| `caching` | 89줄 | 190줄 | Two-level cache, key design, stampede prevention, warming |
| `database` | 91줄 | 204줄 | Migration safety, index order, pagination, isolation levels |

## Test plan

- [ ] 각 SKILL.md의 YAML frontmatter가 유효한지 확인
- [ ] 추가된 코드 예시가 문법적으로 올바른지 확인
- [ ] 테이블 포맷이 깨지지 않았는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)