### PR TITLE
[Fix] ci-cd 스킬 frontmatter >- 형식 통일

### DIFF
--- a/ci-cd/SKILL.md
+++ b/ci-cd/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: ci-cd
-description: CI/CD pipeline patterns with GitHub Actions. Use when writing or
-  reviewing workflow files, deployment pipelines, or branch protection rules.
+description: >-
+  CI/CD pipeline patterns with GitHub Actions.
+  Use when writing or reviewing workflow files, deployment pipelines, or branch protection rules.
 ---
 
 # CI/CD Pipeline Rules


### PR DESCRIPTION
## 요약
- `ci-cd/SKILL.md`의 `description` 필드를 `>-` fold indicator 방식으로 변경
- 38개 이상의 다른 스킬에서 이미 사용 중인 컨벤션에 맞춤

## 테스트 계획
- [x] YAML frontmatter가 정상 파싱되는지 확인
- [x] description 내용이 변경되지 않았는지 확인

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)