### PR TITLE
[Feat] 전 스킬 frontmatter 메타데이터 표준화

### DIFF
--- a/api-design/SKILL.md
+++ b/api-design/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   REST API design principles including URL design, HTTP methods, status codes,
   pagination, versioning, security, and OpenAPI documentation.
   Use when designing or implementing REST APIs.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # REST API Design Rules

--- a/caching/SKILL.md
+++ b/caching/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Framework-agnostic caching strategies including cache selection, TTL design,
   invalidation patterns, stampede prevention, and anti-patterns.
   Use when designing or reviewing cache logic.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Caching Rules

--- a/chaos-engineering/SKILL.md
+++ b/chaos-engineering/SKILL.md
@@ -3,6 +3,16 @@ name: chaos-engineering
 description: >-
   Chaos engineering principles and practices for building resilient systems.
   Use when designing reliability testing, failure injection experiments, or game days.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Skill: Chaos Engineering

--- a/ci-cd/SKILL.md
+++ b/ci-cd/SKILL.md
@@ -3,6 +3,16 @@ name: ci-cd
 description: >-
   CI/CD pipeline patterns with GitHub Actions.
   Use when writing or reviewing workflow files, deployment pipelines, or branch protection rules.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # CI/CD Pipeline Rules

--- a/clean-architecture/SKILL.md
+++ b/clean-architecture/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Clean Architecture and Hexagonal Architecture (Ports & Adapters) patterns.
   Use when designing layered architecture, defining port/adapter boundaries,
   or structuring domain-centric applications.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Clean Architecture / Hexagonal Architecture Rules

--- a/code-quality/SKILL.md
+++ b/code-quality/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Code quality and design principles. Includes refactoring techniques,
   code smell identification, and safe refactoring workflows.
   Use when writing, reviewing, or refactoring code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # Code Quality and Design Principles
 

--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -2,6 +2,16 @@
 name: code-review
 description: Code review checklist and comment guidelines. Use when reviewing pull
   requests or code changes.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # Code Review Rules
 

--- a/concurrency/SKILL.md
+++ b/concurrency/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   JVM concurrency rules including thread safety, synchronization tools,
   Executor framework, CompletableFuture, Kotlin coroutines, and virtual threads.
   Use when writing concurrent or parallel code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # JVM Concurrency Rules

--- a/database/SKILL.md
+++ b/database/SKILL.md
@@ -6,6 +6,16 @@ description: >-
   locking), backup strategies, replication patterns, connection pool tuning,
   and CDC. Includes MySQL and PostgreSQL specific guides.
   Use when writing SQL or designing database access.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Database Rules

--- a/ddd/SKILL.md
+++ b/ddd/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Domain-Driven Design patterns including entities, value objects, aggregates,
   repositories, domain services, domain events, and bounded contexts.
   Use when designing domain models or implementing business logic.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Domain-Driven Design (DDD) Skill

--- a/distributed-systems/SKILL.md
+++ b/distributed-systems/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Distributed systems design patterns including data replication, partitioning,
   distributed time, cluster management, and network communication.
   Use when designing or implementing distributed systems.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Distributed Systems Patterns

--- a/dockerfile/SKILL.md
+++ b/dockerfile/SKILL.md
@@ -6,6 +6,16 @@ description: >-
   (cache/secret mounts), multi-architecture builds, signal handling,
   and image provenance (cosign, SBOM).
   Use when writing or reviewing Dockerfiles.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Dockerfile Rules

--- a/error-handling/SKILL.md
+++ b/error-handling/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Framework-agnostic error handling patterns including exception hierarchy,
   error classification, response format, and handling principles.
   Use when designing error handling strategies.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # Error Handling Rules
 

--- a/exposed/SKILL.md
+++ b/exposed/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Jetbrains Exposed ORM rules including DSL vs DAO, table definition,
   query patterns, transaction management, and schema migration.
   Use when writing Exposed ORM code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Exposed ORM Rules

--- a/git-workflow/SKILL.md
+++ b/git-workflow/SKILL.md
@@ -2,6 +2,16 @@
 name: git-workflow
 description: Git commit conventions and branch strategy rules. Use when committing
   code or managing branches.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Git Workflow Rules

--- a/gitops-argocd/SKILL.md
+++ b/gitops-argocd/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   secret management, multi-cluster deployment, rollback, notifications, and
   CI/CD integration. Covers ApplicationSet patterns and progressive delivery.
   Use when implementing GitOps workflows or managing Argo CD configurations.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # GitOps with Argo CD Rules

--- a/gradle-convention/SKILL.md
+++ b/gradle-convention/SKILL.md
@@ -3,6 +3,16 @@ name: gradle-convention
 description: Gradle build conventions for Kotlin/JVM multi-module projects.
   Use when writing or reviewing build.gradle.kts, settings.gradle.kts, or version
   catalog files.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Gradle Convention Rules

--- a/helm-workflow/SKILL.md
+++ b/helm-workflow/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   values design, template best practices, hooks, dependency management,
   testing, and repository management. Covers Helm vs Kustomize selection.
   Use when creating, reviewing, or managing Helm charts.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Helm Workflow Rules

--- a/http-client/SKILL.md
+++ b/http-client/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Framework-agnostic external API integration patterns including timeouts,
   error handling, retry strategy, circuit breaker, and response mapping.
   Use when writing or reviewing HTTP client code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # External API Client Rules
 

--- a/incident-response/SKILL.md
+++ b/incident-response/SKILL.md
@@ -7,6 +7,16 @@ description: >-
   and SLO/SLI/SLA relationships.
   Use when handling production incidents, writing runbooks, or establishing
   incident response procedures.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Incident Response Rules

--- a/java-convention/SKILL.md
+++ b/java-convention/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Java coding conventions and modern idioms.
   Includes version migration guide (8 → 11 → 17 → 21 → 25).
   Use when writing or reviewing Java code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Java Convention Rules

--- a/java-kotlin-interop/SKILL.md
+++ b/java-kotlin-interop/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Java-Kotlin interoperability guide covering platform types, null safety with JSpecify,
   JVM annotations (@JvmStatic, @JvmOverloads, @JvmExposeBoxed, @Throws), collection interop,
   coroutine-Java bridging, SAM conversion, and build configuration for mixed projects.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Java-Kotlin Interoperability Rules

--- a/jvm-performance/SKILL.md
+++ b/jvm-performance/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   JVM performance tuning including garbage collection algorithms, GC selection,
   heap analysis, profiling tools, and cloud-native considerations.
   Use when diagnosing performance issues or tuning JVM parameters.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # JVM Performance Optimization

--- a/k8s-workflow/SKILL.md
+++ b/k8s-workflow/SKILL.md
@@ -7,6 +7,16 @@ description: >-
   Gateway API, NetworkPolicy, Service Mesh), storage (PV/PVC, StatefulSet),
   RBAC, and deployment strategies (Rolling, Blue-Green, Canary).
   Use for Kubernetes operations and manifest authoring.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Kubernetes Workflow Rules

--- a/karpenter-workflow/SKILL.md
+++ b/karpenter-workflow/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   and troubleshooting. Includes cloud provider configurations
   (AWS EC2NodeClass, Azure AKSNodeClass, GCP GKENodeClass).
   Use for Karpenter operations.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Karpenter Workflow Guide

--- a/kotlin-convention/SKILL.md
+++ b/kotlin-convention/SKILL.md
@@ -2,6 +2,16 @@
 name: kotlin-convention
 description: Kotlin coding conventions and idioms. Use when writing or reviewing
   Kotlin code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Kotlin Convention Rules

--- a/logging/SKILL.md
+++ b/logging/SKILL.md
@@ -2,6 +2,16 @@
 name: logging
 description: Logging standards and sensitive data handling. Use when writing logging
   code or reviewing logs.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Logging Rules

--- a/messaging/SKILL.md
+++ b/messaging/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Async messaging patterns including broker selection, message design,
   producer/consumer patterns, schema evolution, and monitoring.
   Use when implementing Kafka, RabbitMQ, or event-driven architecture.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # Messaging Rules
 

--- a/microservices/SKILL.md
+++ b/microservices/SKILL.md
@@ -6,6 +6,16 @@ description: >-
   data management, and fault isolation (Circuit Breaker, Bulkhead).
   Use when designing or reviewing microservice architectures, or implementing
   distributed transactions, service discovery, or strangler fig migration.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Microservices Architecture Pattern Rules

--- a/monitoring/SKILL.md
+++ b/monitoring/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   Micrometer), logging, distributed tracing (OpenTelemetry, traceId),
   alerting rules, and health check concepts (liveness, readiness, startup).
   Use when implementing monitoring, alerting, or observability.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # Monitoring and Observability Rules
 

--- a/object-oriented-design/SKILL.md
+++ b/object-oriented-design/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Object-oriented design principles (SOLID) with practical examples.
   Use when designing class hierarchies, applying SOLID principles,
   or reviewing object-oriented design.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Object-Oriented Design Principles (SOLID Advanced)

--- a/pdf-handling/SKILL.md
+++ b/pdf-handling/SKILL.md
@@ -3,6 +3,16 @@ name: pdf-handling
 description: >-
   PDF file reading and processing rules.
   Use when analyzing PDF files or extracting content from them.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # PDF File Handling Rules

--- a/resume-writing/SKILL.md
+++ b/resume-writing/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Developer resume writing guide including structure, experience description
   with STAR method, technical skills organization, and project description.
   Use when writing or reviewing a developer resume.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # Developer Resume Rules
 

--- a/secrets-management/SKILL.md
+++ b/secrets-management/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   Kubernetes patterns (ESO, Sealed Secrets, CSI), CI/CD pipeline secrets,
   certificate management, and secret detection/prevention.
   Use when managing secrets, credentials, or certificates in any environment.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Secrets Management Rules

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   CORS, API headers, rate limiting, secret management, authentication patterns
   (JWT, OAuth2, session, MFA), and web protection (CSRF, XSS, injection defense, TLS).
   Use when implementing security-related code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # Security Rules
 

--- a/spring-framework/SKILL.md
+++ b/spring-framework/SKILL.md
@@ -10,6 +10,16 @@ description: >-
   Includes migration guides for Framework (5.x → 7.0) and Boot (2.7 → 4.0).
   Use when working with Spring Framework or Spring Boot features, Actuator health probes,
   Bean Validation, @Transactional, RestClient, WebClient, or Spring Security.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Spring Framework Core Rules

--- a/system-design/SKILL.md
+++ b/system-design/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   CDN, stateless design, message queues, consistent hashing, and rate limiting.
   Includes system stability patterns (circuit breaker, bulkhead, backpressure).
   Use when designing scalable system architectures.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # System Design Interview Patterns

--- a/technical-documentation/SKILL.md
+++ b/technical-documentation/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Technical documentation guide covering writing principles, user research,
   deployment process, and quality measurement.
   Use when writing or reviewing technical documentation.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Technical Documentation Guide

--- a/terraform-workflow/SKILL.md
+++ b/terraform-workflow/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   and version considerations. Includes provider-specific guides for AWS (v6.x),
   Azure (v4.x), and GCP (v6.x).
   Use for Terraform operations and best practices.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # Terraform Workflow Rules
 

--- a/testing/SKILL.md
+++ b/testing/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   testing with Testcontainers, contract testing for microservices (Pact,
   Spring Cloud Contract), and performance testing strategies (k6, Gatling).
   Use when writing or modifying test code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # BDD-Style Unit Test Rules
 

--- a/troubleshooting/SKILL.md
+++ b/troubleshooting/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   rollback, connection issues, OOMKilled pods, CrashLoopBackOff, and
   debugging principles.
   Use when diagnosing errors, deployment issues, or production problems.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 # Troubleshooting Rules
 

--- a/weather/SKILL.md
+++ b/weather/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Weather and air quality information lookup using KMA (기상청), AirKorea, and AccuWeather.
   Use when users ask for current weather, weather forecasts, hourly forecasts, weather conditions,
   sunrise/sunset times, UV index, air quality (미세먼지/초미세먼지), or past/historical weather observations.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Weather Information Rules


### PR DESCRIPTION
## 요약
- 42개 전체 스킬의 SKILL.md frontmatter에 표준 메타데이터 필드 추가
  - `license: MIT`
  - `metadata` (author, version, last-reviewed)
  - `compatibility` (OpenCode, Claude Code, Codex, Antigravity)
- 기존 `name`, `description` 필드는 변경 없음

## 테스트 계획
- [x] YAML frontmatter가 정상 파싱되는지 확인
- [x] 기존 name, description 필드가 변경되지 않았는지 확인
- [x] 여러 스킬을 랜덤 샘플링하여 올바른 형식 확인

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)