### PR TITLE
fix: 5개 스킬 SKILL.md frontmatter 필수 필드 누락 수정

### DIFF
--- a/load-testing/SKILL.md
+++ b/load-testing/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   Load and performance testing best practices with k6 and Gatling including
   test design, metrics, thresholds, CI integration, and result analysis.
   Use when designing or implementing performance tests.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Load Testing Rules

--- a/openapi-spec/SKILL.md
+++ b/openapi-spec/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   documentation generation, validation, versioning, and code generation
   patterns.
   Use when writing, reviewing, or maintaining OpenAPI specifications.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # OpenAPI Specification Rules

--- a/prompt-engineering/SKILL.md
+++ b/prompt-engineering/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   prompt design patterns, structured output, evaluation, safety, and
   cost optimization.
   Use when building or reviewing AI-powered features that interact with LLMs.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # Prompt Engineering Rules

--- a/react-convention/SKILL.md
+++ b/react-convention/SKILL.md
@@ -4,6 +4,16 @@ description: >-
   React and Next.js coding conventions including component patterns, hooks,
   state management, performance optimization, and project structure.
   Use when writing, reviewing, or refactoring React/Next.js code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # React/Next.js Coding Conventions

--- a/typescript-convention/SKILL.md
+++ b/typescript-convention/SKILL.md
@@ -5,6 +5,16 @@ description: >-
   strict mode configuration, utility types, error handling, and project
   organization patterns.
   Use when writing, reviewing, or refactoring TypeScript code.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
 ---
 
 # TypeScript Coding Conventions


### PR DESCRIPTION
## 요약

- `prompt-engineering`, `load-testing`, `openapi-spec`, `react-convention`, `typescript-convention` 5개 스킬의 SKILL.md frontmatter에 누락된 `license`, `metadata`, `compatibility` 필드를 추가했습니다
- 기존 스킬(`api-design`, `spring-framework` 등)의 frontmatter 형식과 동일하게 맞추었습니다

## 변경 파일

- `prompt-engineering/SKILL.md`
- `load-testing/SKILL.md`
- `openapi-spec/SKILL.md`
- `react-convention/SKILL.md`
- `typescript-convention/SKILL.md`

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)