### PR TITLE
improve: 10개 스킬 description 트리거 키워드 보강

### DIFF
--- a/chaos-engineering/SKILL.md
+++ b/chaos-engineering/SKILL.md
@@ -2,7 +2,12 @@
 name: chaos-engineering
 description: >-
   Chaos engineering principles and practices for building resilient systems.
-  Use when designing reliability testing, failure injection experiments, or game days.
+  Covers tools such as Chaos Monkey, Gremlin, and Litmus for fault injection,
+  blast radius analysis, steady state hypothesis definition, experiment design,
+  failure mode validation, and game day planning.
+  Use when designing reliability testing, running fault injection experiments,
+  defining steady state hypotheses, or planning chaos game days to verify
+  system resilience.
 license: MIT
 metadata:
   author: iceflower

--- a/clean-architecture/SKILL.md
+++ b/clean-architecture/SKILL.md
@@ -2,8 +2,12 @@
 name: clean-architecture
 description: >-
   Clean Architecture and Hexagonal Architecture (Ports & Adapters) patterns.
+  Covers the dependency rule, domain layer isolation, use case (application service)
+  design, repository pattern, input/output port definitions, adapter implementation,
+  and onion architecture layering.
   Use when designing layered architecture, defining port/adapter boundaries,
-  or structuring domain-centric applications.
+  structuring domain-centric applications, or enforcing the dependency rule
+  between infrastructure and domain layers.
 license: MIT
 metadata:
   author: iceflower

--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: code-review
-description: Code review checklist and comment guidelines. Use when reviewing pull
-  requests or code changes.
+description: >-
+  Code review checklist, comment guidelines, and PR review best practices.
+  Covers PR review workflows, code suggestions, nitpick vs blocking review
+  classification, LGTM criteria, review checklist (correctness, security,
+  performance, readability), and constructive feedback patterns.
+  Use when reviewing pull requests, providing code suggestions, or establishing
+  a team code review process and review comment conventions.
 license: MIT
 metadata:
   author: iceflower

--- a/git-workflow/SKILL.md
+++ b/git-workflow/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: git-workflow
-description: Git commit conventions and branch strategy rules. Use when committing
-  code or managing branches.
+description: >-
+  Git commit conventions, branch strategy, and collaboration workflow rules.
+  Covers conventional commits, commit message formatting, squash merge, rebase,
+  interactive rebase, branch naming conventions, merge conflict resolution,
+  cherry-pick, git bisect, and pull request workflows.
+  Use when committing code, managing branches, resolving merge conflicts,
+  or defining a team Git branching strategy.
 license: MIT
 metadata:
   author: iceflower

--- a/gradle-convention/SKILL.md
+++ b/gradle-convention/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: gradle-convention
-description: Gradle build conventions for Kotlin/JVM multi-module projects.
-  Use when writing or reviewing build.gradle.kts, settings.gradle.kts, or version
-  catalog files.
+description: >-
+  Gradle build conventions for Kotlin/JVM multi-module projects.
+  Covers multi-module project structure, convention plugins, buildSrc setup,
+  dependency management with version catalogs, Gradle wrapper configuration,
+  build cache configuration, task optimization, and plugin publishing.
+  Use when writing or reviewing build.gradle.kts, settings.gradle.kts, version
+  catalog files, or configuring convention plugins for shared build logic.
 license: MIT
 metadata:
   author: iceflower

--- a/kotlin-convention/SKILL.md
+++ b/kotlin-convention/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: kotlin-convention
-description: Kotlin coding conventions and idioms. Use when writing or reviewing
-  Kotlin code.
+description: >-
+  Kotlin coding conventions, idioms, and language-specific best practices.
+  Covers null safety, data class, sealed class, enum class, extension functions,
+  coroutines, Flow, when expression, scope functions (let, run, apply, also),
+  collection operations, and Kotlin DSL patterns.
+  Use when writing or reviewing Kotlin code, designing domain models with
+  sealed hierarchies, or implementing asynchronous logic with coroutines and Flow.
 license: MIT
 metadata:
   author: iceflower

--- a/logging/SKILL.md
+++ b/logging/SKILL.md
@@ -1,7 +1,12 @@
 ---
 name: logging
-description: Logging standards and sensitive data handling. Use when writing logging
-  code or reviewing logs.
+description: >-
+  Logging standards, structured logging, and sensitive data handling.
+  Covers log levels (DEBUG, INFO, WARN, ERROR, TRACE), MDC (Mapped Diagnostic Context),
+  correlation ID propagation, log format standardization, sensitive data masking,
+  and log aggregation best practices.
+  Use when writing logging code, configuring log frameworks (Logback, Log4j2),
+  reviewing log output, or implementing request tracing with correlation IDs.
 license: MIT
 metadata:
   author: iceflower

--- a/object-oriented-design/SKILL.md
+++ b/object-oriented-design/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: object-oriented-design
 description: >-
-  Object-oriented design principles (SOLID) with practical examples.
-  Use when designing class hierarchies, applying SOLID principles,
-  or reviewing object-oriented design.
+  Object-oriented design principles with practical examples covering all five
+  SOLID principles: Single Responsibility (SRP), Open/Closed (OCP), Liskov
+  Substitution (LSP), Interface Segregation (ISP), and Dependency Inversion (DIP).
+  Includes design patterns, class hierarchy design, and refactoring guidance.
+  Use when designing class hierarchies, applying SOLID principles, refactoring
+  toward better abstractions, or reviewing object-oriented design for violations.
 license: MIT
 metadata:
   author: iceflower

--- a/system-design/SKILL.md
+++ b/system-design/SKILL.md
@@ -3,8 +3,11 @@ name: system-design
 description: >-
   Large-scale system design patterns including database architecture, caching,
   CDN, stateless design, message queues, consistent hashing, and rate limiting.
-  Includes system stability patterns (circuit breaker, bulkhead, backpressure).
-  Use when designing scalable system architectures.
+  Covers CAP theorem, eventual consistency, sharding strategies, replication factor,
+  read replica configuration, and system stability patterns (circuit breaker,
+  bulkhead, backpressure).
+  Use when designing scalable system architectures, evaluating consistency vs
+  availability trade-offs, or planning data partitioning and replication strategies.
 license: MIT
 metadata:
   author: iceflower

--- a/troubleshooting/SKILL.md
+++ b/troubleshooting/SKILL.md
@@ -3,8 +3,11 @@ name: troubleshooting
 description: >-
   General debugging and troubleshooting patterns for slow APIs, deployment
   rollback, connection issues, OOMKilled pods, CrashLoopBackOff, and
-  debugging principles.
-  Use when diagnosing errors, deployment issues, or production problems.
+  debugging principles. Covers root cause analysis, incident triage workflows,
+  error stack trace analysis, pod logs inspection, metrics anomaly detection,
+  alert investigation, and systematic debugging methodologies.
+  Use when diagnosing errors, performing root cause analysis on production
+  incidents, investigating alert anomalies, or triaging deployment failures.
 license: MIT
 metadata:
   author: iceflower


### PR DESCRIPTION
## 요약

- 10개 스킬의 SKILL.md frontmatter description에 트리거 키워드를 보강하여 에이전트의 스킬 매칭 정확도를 향상
- 각 description을 3줄 이상으로 확장하고, 5개 이상의 구체적인 기술명/키워드를 포함
- 모든 description에 구체적인 시나리오를 명시한 Use when 문장을 포함

## 품질 가이드라인 준수

- **3줄 이상**: 모든 10개 스킬의 description이 3줄 이상으로 확장됨
- **키워드 5개 이상**: 각 스킬별로 5개 이상의 구체적인 기술명/키워드 포함
- **Use when 필수**: 모든 description에 구체적인 시나리오를 명시한 Use when 문장 포함

## 변경 파일

### 우선순위 높음
- `git-workflow/SKILL.md` — conventional commits, squash merge, rebase, branch naming, merge conflict, cherry-pick, git bisect
- `logging/SKILL.md` — structured logging, log levels, MDC, correlation ID, sensitive data masking, Logback, Log4j2
- `kotlin-convention/SKILL.md` — data class, sealed class, extension functions, coroutines, Flow, null safety, when expression

### 우선순위 중간
- `system-design/SKILL.md` — CAP theorem, eventual consistency, sharding, replication factor, read replica
- `object-oriented-design/SKILL.md` — Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, Dependency Inversion
- `clean-architecture/SKILL.md` — hexagonal architecture, domain layer, use case, repository pattern, dependency rule
- `gradle-convention/SKILL.md` — multi-module, convention plugins, buildSrc, dependency management, Gradle wrapper, cache configuration
- `troubleshooting/SKILL.md` — root cause analysis, incident triage, error stack trace, pod logs, metrics anomaly, alert investigation

### 우선순위 낮음
- `code-review/SKILL.md` — PR review, code suggestions, nitpick, blocking review, LGTM, review checklist
- `chaos-engineering/SKILL.md` — Chaos Monkey, Gremlin, Litmus, fault injection, blast radius, steady state

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
