### PR TITLE
feat: Spring AI 스킬 추가

### DIFF
--- a/spring-ai/SKILL.md
+++ b/spring-ai/SKILL.md
@@ -1,0 +1,437 @@
+---
+name: spring-ai
+description: >-
+  Spring AI conventions and patterns for building AI-powered applications
+  including ChatClient configuration, tool/function calling, prompt template
+  management, vector store integration, RAG (Retrieval Augmented Generation),
+  Advisors API, MCP (Model Context Protocol) integration, and multi-model
+  routing patterns.
+  Use when building or reviewing Spring AI applications, integrating LLMs
+  with Spring Boot, implementing ChatClient, configuring tool calling,
+  designing prompt templates, or working with vector databases in Spring.
+license: MIT
+metadata:
+  author: iceflower
+  version: "1.0"
+  last-reviewed: "2026-03"
+compatibility:
+  - OpenCode
+  - Claude Code
+  - Codex
+  - Antigravity
+---
+
+# Spring AI Core Rules
+
+## 1. ChatClient Configuration
+
+> See [references/chatclient-patterns.md](references/chatclient-patterns.md) for detailed fluent API usage, streaming patterns, and structured output.
+
+### Key Rules
+
+- Inject `ChatClient.Builder` (auto-configured), not `ChatClient` directly — build in constructor or `@Bean`
+- Use `ChatClient.create(chatModel)` only for simple cases — prefer builder for defaults
+- Set default system prompt, advisors, and tools on the builder — override per-request as needed
+- Use `.call()` for synchronous responses, `.stream()` for reactive `Flux` responses
+- Use `.entity(Class<T>)` for structured output — Spring AI handles JSON schema generation
+- Always configure `spring.ai.retry` properties for production resilience
+
+### ChatClient Creation
+
+```java
+@RestController
+class MyController {
+    private final ChatClient chatClient;
+
+    public MyController(ChatClient.Builder builder) {
+        this.chatClient = builder
+            .defaultSystem("You are a helpful assistant.")
+            .build();
+    }
+}
+```
+
+---
+
+## 2. Tool/Function Calling
+
+> See [references/tool-calling.md](references/tool-calling.md) for detailed @Tool annotation usage, ToolCallback interface, and migration patterns.
+
+### Tool Calling Rules
+
+- Use `@Tool` annotation for declarative tool definitions — method name becomes tool name by default
+- Always provide descriptive `description` — the model uses it to decide when to call the tool
+- Use `@ToolParam(description = "...")` for parameter descriptions — improves model accuracy
+- Register tools via `.tools(new MyTools())` on ChatClient or `.defaultTools()` on builder
+- Use `ToolContext` to pass application context (tenant ID, user info) without exposing to the model
+- Tool methods must not return reactive types (`Mono`, `Flux`) — tool calling is synchronous
+- Set `returnDirect = true` on `@Tool` when the tool result should go directly to the user
+
+### Tool Definition Example
+
+```java
+class WeatherTools {
+    @Tool(description = "Get current weather for a given city")
+    String getWeather(
+        @ToolParam(description = "City name") String city,
+        @ToolParam(description = "Temperature unit", required = false) String unit
+    ) {
+        return weatherService.getCurrentWeather(city, unit);
+    }
+}
+
+// Register with ChatClient
+chatClient.prompt()
+    .tools(new WeatherTools())
+    .user("What is the weather in Seoul?")
+    .call()
+    .content();
+```
+
+---
+
+## 3. Prompt Template Management
+
+### PromptTemplate
+
+```java
+// Inline template with {placeholder} syntax
+chatClient.prompt()
+    .user(u -> u
+        .text("Tell me about {topic} in {language}")
+        .param("topic", "Spring AI")
+        .param("language", "Korean"))
+    .call()
+    .content();
+
+// From resource file
+chatClient.prompt()
+    .user(u -> u
+        .text(new ClassPathResource("prompts/summary.st"))
+        .param("document", documentText))
+    .call()
+    .content();
+```
+
+### Prompt Template Rules
+
+- Use `{placeholder}` syntax for template variables (default StringTemplate renderer)
+- Store complex prompts in `src/main/resources/prompts/` as `.st` files
+- Use `.system()` for persona/instruction, `.user()` for task-specific input
+- Use `TemplateRenderer` customization for non-default delimiters
+- Never hardcode long prompts inline — extract to resource files for maintainability
+
+---
+
+## 4. Vector Store Integration
+
+> See [references/vector-store-rag.md](references/vector-store-rag.md) for detailed vector store patterns, supported databases, and RAG implementation.
+
+### Vector Store Rules
+
+- Use `VectorStore` interface for write operations (`add`, `delete`), `VectorStoreRetriever` for read-only
+- Use `SearchRequest.builder()` to configure `topK`, `similarityThreshold`, and `filterExpression`
+- Default `topK` is 4 and `similarityThreshold` is 0.0 (accept all) — tune for your use case
+- Use metadata filtering for multi-tenant isolation (e.g., `"tenantId == 'acme'"`)
+- Configure `BatchingStrategy` for large document ingestion — default is `TokenCountBatchingStrategy`
+
+### Basic Usage
+
+```java
+// Add documents
+vectorStore.add(List.of(
+    new Document("Spring AI simplifies AI integration.", Map.of("topic", "spring-ai")),
+    new Document("RAG improves answer accuracy.", Map.of("topic", "rag"))
+));
+
+// Search
+List<Document> results = vectorStore.similaritySearch(
+    SearchRequest.builder()
+        .query("How does RAG work?")
+        .topK(5)
+        .similarityThreshold(0.7)
+        .filterExpression("topic == 'rag'")
+        .build()
+);
+```
+
+---
+
+## 5. RAG (Retrieval Augmented Generation)
+
+> See [references/vector-store-rag.md](references/vector-store-rag.md) for detailed RAG advisor configuration and query transformation.
+
+### RAG Rules
+
+- Use `QuestionAnswerAdvisor` for simple RAG — single vector store, no query transformation
+- Use `RetrievalAugmentationAdvisor` for advanced RAG — supports query transformers and custom augmenters
+- Always set a meaningful `similarityThreshold` (e.g., 0.5-0.8) — 0.0 returns irrelevant results
+- Use `ContextualQueryAugmenter.builder().allowEmptyContext(true)` to let the model answer without context
+- Use `RewriteQueryTransformer` or `CompressionQueryTransformer` for better retrieval accuracy
+
+### Quick RAG Setup
+
+```java
+// Simple RAG with QuestionAnswerAdvisor
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(
+        QuestionAnswerAdvisor.builder(vectorStore)
+            .searchRequest(SearchRequest.builder()
+                .similarityThreshold(0.7)
+                .topK(5)
+                .build())
+            .build())
+    .build();
+
+String answer = chatClient.prompt()
+    .user("What is Spring AI?")
+    .call()
+    .content();
+```
+
+---
+
+## 6. Advisors API
+
+### Advisor Chain
+
+Advisors intercept and modify ChatClient requests and responses in a chain pattern, similar to servlet filters.
+
+```java
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(
+        MessageChatMemoryAdvisor.builder(chatMemory).build(),
+        QuestionAnswerAdvisor.builder(vectorStore).build(),
+        new SimpleLoggerAdvisor()
+    )
+    .build();
+```
+
+### Key Interfaces
+
+| Interface        | Purpose                      | Key Method                             |
+| ---------------- | ---------------------------- | -------------------------------------- |
+| `CallAdvisor`    | Synchronous interception     | `adviseCall(request, chain)`           |
+| `StreamAdvisor`  | Streaming interception       | `adviseStream(request, chain)`         |
+
+### Ordering Rules
+
+- Lower `getOrder()` value = higher priority (processed first on request, last on response)
+- Use `Ordered.HIGHEST_PRECEDENCE` for security/auth advisors
+- Use `Ordered.LOWEST_PRECEDENCE` for logging advisors
+
+### Built-in Advisors
+
+| Advisor                         | Purpose                                 |
+| ------------------------------- | --------------------------------------- |
+| `MessageChatMemoryAdvisor`      | Conversation memory via message history |
+| `PromptChatMemoryAdvisor`       | Memory incorporated into system prompt  |
+| `VectorStoreChatMemoryAdvisor`  | Memory retrieval from vector store      |
+| `QuestionAnswerAdvisor`         | Simple RAG pattern                      |
+| `RetrievalAugmentationAdvisor`  | Advanced modular RAG                    |
+| `SafeGuardAdvisor`              | Content safety filtering                |
+| `ReReadingAdvisor`              | RE2 technique for better reasoning      |
+| `SimpleLoggerAdvisor`           | Request/response logging                |
+
+---
+
+## 7. MCP (Model Context Protocol) Integration
+
+### Overview
+
+Spring AI provides MCP integration through Boot starters for both client and server roles.
+
+### Client Setup
+
+```xml
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-mcp-client</artifactId>
+</dependency>
+```
+
+### Server Setup
+
+```xml
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
+</dependency>
+```
+
+### Server Annotations
+
+```java
+@McpTool          // Expose tools to MCP clients
+@McpResource      // Expose resources via URI-based access
+@McpPrompt        // Provide prompt templates
+```
+
+### Transport Options
+
+| Transport            | Use Case                        | Property                                   |
+| -------------------- | ------------------------------- | ------------------------------------------ |
+| STDIO                | Local process communication     | `spring.ai.mcp.server.stdio=true`          |
+| SSE                  | Server-Sent Events over HTTP    | `spring.ai.mcp.server.protocol=SSE`        |
+| Streamable-HTTP      | Bidirectional HTTP streaming    | `spring.ai.mcp.server.protocol=STREAMABLE` |
+| Stateless Streamable | Stateless HTTP without sessions | `spring.ai.mcp.server.protocol=STATELESS`  |
+
+### MCP Rules
+
+- Use `spring-ai-starter-mcp-client` for consuming external MCP servers
+- Use `spring-ai-starter-mcp-server-webmvc` or `webflux` for exposing tools as MCP server
+- Annotate tool methods with `@McpTool` for automatic discovery
+- Choose transport based on deployment: STDIO for local, SSE/Streamable-HTTP for remote
+
+---
+
+## 8. Multi-Model Routing
+
+### ChatModel Abstraction
+
+Spring AI provides a unified `ChatModel` interface across all providers, enabling model-agnostic code.
+
+### Multiple Model Configuration
+
+```java
+@Configuration
+public class MultiModelConfig {
+
+    @Bean
+    @Qualifier("fast")
+    public ChatClient fastClient(OpenAiChatModel openAiModel) {
+        return ChatClient.builder(openAiModel)
+            .defaultOptions(OpenAiChatOptions.builder()
+                .model("gpt-4o-mini")
+                .temperature(0.3)
+                .build())
+            .build();
+    }
+
+    @Bean
+    @Qualifier("powerful")
+    public ChatClient powerfulClient(AnthropicChatModel anthropicModel) {
+        return ChatClient.builder(anthropicModel)
+            .defaultOptions(AnthropicChatOptions.builder()
+                .model("claude-sonnet-4-20250514")
+                .build())
+            .build();
+    }
+}
+```
+
+### Routing Pattern
+
+```java
+@Service
+public class ModelRouter {
+    private final ChatClient fastClient;
+    private final ChatClient powerfulClient;
+
+    public ChatClient route(String taskType) {
+        return switch (taskType) {
+            case "summarize", "classify" -> fastClient;
+            case "analyze", "generate" -> powerfulClient;
+            default -> fastClient;
+        };
+    }
+}
+```
+
+### Routing Rules
+
+- Use `@Qualifier` to distinguish multiple `ChatClient` beans
+- Configure model-specific options via provider `ChatOptions` (e.g., `OpenAiChatOptions`)
+- Route based on task complexity — use cheaper/faster models for simple tasks
+- Use `ChatModel.mutate()` for runtime model switching with OpenAI-compatible endpoints
+
+---
+
+## 9. Agent Building Patterns
+
+### ReAct Agent with Tool Loop
+
+```java
+ChatClient agentClient = ChatClient.builder(chatModel)
+    .defaultSystem("""
+        You are a helpful assistant. Use the provided tools to answer questions.
+        Think step by step before answering.
+        """)
+    .defaultTools(new SearchTools(), new CalculatorTools())
+    .build();
+
+String result = agentClient.prompt()
+    .user(userQuestion)
+    .call()
+    .content();
+```
+
+### Agent with Memory and RAG
+
+```java
+ChatClient agentClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(
+        MessageChatMemoryAdvisor.builder(chatMemory).build(),
+        RetrievalAugmentationAdvisor.builder()
+            .documentRetriever(VectorStoreDocumentRetriever.builder()
+                .vectorStore(vectorStore)
+                .similarityThreshold(0.6)
+                .build())
+            .build()
+    )
+    .defaultTools(new CustomerTools())
+    .build();
+```
+
+### Agent Building Rules
+
+- Combine advisors (memory + RAG) with tools for capable agents
+- Use `MessageChatMemoryAdvisor` for multi-turn conversations
+- Pass conversation ID via `.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, id))`
+- Keep tool descriptions clear and specific — vague descriptions cause incorrect tool selection
+- Monitor token usage — agents with many tools and long memory consume more tokens
+
+---
+
+## 10. Error Handling and Cost Optimization
+
+### Error Handling
+
+```java
+// Configure retry behavior
+// application.yml
+spring:
+  ai:
+    retry:
+      max-attempts: 3
+      backoff:
+        initial-interval: 1000
+        multiplier: 2.0
+        max-interval: 10000
+
+// Tool execution error handling
+@Bean
+ToolExecutionExceptionProcessor toolErrorProcessor() {
+    return exception -> "Tool execution failed: " + exception.getMessage();
+}
+```
+
+### Cost Optimization Rules
+
+- Use structured output (`.entity()`) to reduce unnecessary tokens in responses
+- Set appropriate `maxTokens` in `ChatOptions` to cap response length
+- Use cheaper models for simple tasks (classification, summarization)
+- Cache frequently asked questions and their responses
+- Use `similarityThreshold` in RAG to avoid sending irrelevant context
+- Monitor token usage via `ChatResponse.getMetadata().getUsage()`
+- Use streaming (`.stream()`) for better user experience, not for cost savings — token count is the same
+
+### Anti-Patterns
+
+- Creating a new `ChatClient` per request — build once, reuse the instance
+- Using expensive models for simple classification tasks — route by complexity
+- Setting `similarityThreshold` to 0.0 in production — floods context with irrelevant documents
+- Ignoring retry configuration — API calls fail without proper retry/backoff
+- Hardcoding API keys — use `spring.ai.<provider>.api-key` from environment variables
+- Returning JPA entities from `@Tool` methods — use simple DTOs or Strings
+- Blocking the event loop with tool calls in WebFlux — tool calling is inherently blocking

--- a/spring-ai/references/chatclient-patterns.md
+++ b/spring-ai/references/chatclient-patterns.md
@@ -1,0 +1,302 @@
+# ChatClient Patterns
+
+## ChatClient Creation
+
+### Auto-configured Builder (Recommended)
+
+```java
+@RestController
+class ChatController {
+    private final ChatClient chatClient;
+
+    public ChatController(ChatClient.Builder builder) {
+        this.chatClient = builder
+            .defaultSystem("You are a helpful assistant.")
+            .defaultAdvisors(new SimpleLoggerAdvisor())
+            .build();
+    }
+}
+```
+
+### Programmatic Creation
+
+```java
+ChatModel chatModel = ...; // auto-configured by Spring Boot
+
+// Simple
+ChatClient chatClient = ChatClient.create(chatModel);
+
+// With builder
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultSystem("You are a helpful assistant.")
+    .defaultOptions(OpenAiChatOptions.builder()
+        .model("gpt-4o")
+        .temperature(0.7)
+        .build())
+    .build();
+```
+
+## Fluent API Reference
+
+### Prompt Initialization
+
+```java
+chatClient.prompt()                     // Empty prompt
+chatClient.prompt("User message")       // Shorthand for user message
+chatClient.prompt(new Prompt(messages)) // From Prompt object
+```
+
+### Message Building
+
+```java
+// System message
+.system("You are a helpful assistant")
+.system(new ClassPathResource("prompts/system.st"))
+.system(s -> s.text("Act as a {role}").param("role", "teacher"))
+
+// User message
+.user("Tell me a joke")
+.user(new ClassPathResource("prompts/user.st"))
+.user(u -> u
+    .text("Tell me about {topic}")
+    .param("topic", "Spring AI"))
+```
+
+### Message Metadata
+
+```java
+.user(u -> u
+    .text("What is the weather?")
+    .metadata("messageId", "msg-123")
+    .metadata("userId", "user-456"))
+
+.system(s -> s
+    .text("You are helpful")
+    .metadata("version", "1.0"))
+```
+
+Metadata rules:
+
+- Keys cannot be null or empty
+- Values cannot be null
+- Map entries cannot contain null elements
+
+### Options and Advisors
+
+```java
+.options(OpenAiChatOptions.builder()
+    .model("gpt-4o")
+    .temperature(0.5)
+    .build())
+
+.advisors(
+    MessageChatMemoryAdvisor.builder(chatMemory).build(),
+    new SimpleLoggerAdvisor())
+
+.advisors(a -> a.param(ChatMemory.CONVERSATION_ID, "session-123"))
+```
+
+### Tools
+
+```java
+.tools(new DateTimeTools())                        // Tool object
+.toolCallbacks(ToolCallbacks.from(new MyTools()))   // ToolCallback array
+.toolNames("currentWeather")                        // Resolve by bean name
+.toolContext(Map.of("tenantId", "acme"))             // Tool context
+```
+
+## Response Handling
+
+### Synchronous Responses
+
+```java
+// String content
+String content = chatClient.prompt()
+    .user("Tell me a joke")
+    .call()
+    .content();
+
+// Full ChatResponse
+ChatResponse response = chatClient.prompt()
+    .user("Tell me a joke")
+    .call()
+    .chatResponse();
+
+// ChatClientResponse (includes advisor context)
+ChatClientResponse clientResponse = chatClient.prompt()
+    .user("Tell me a joke")
+    .call()
+    .chatClientResponse();
+```
+
+### Structured Output (Entity Mapping)
+
+```java
+record ActorFilms(String actor, List<String> movies) {}
+
+// Single entity
+ActorFilms films = chatClient.prompt()
+    .user("Generate filmography for Tom Hanks")
+    .call()
+    .entity(ActorFilms.class);
+
+// Generic types
+List<ActorFilms> filmsList = chatClient.prompt()
+    .user("Generate filmographies for 3 actors")
+    .call()
+    .entity(new ParameterizedTypeReference<List<ActorFilms>>() {});
+
+// With native structured output support
+ActorFilms films = chatClient.prompt()
+    .advisors(AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT)
+    .user("Generate filmography for Tom Hanks")
+    .call()
+    .entity(ActorFilms.class);
+
+// Entity with ChatResponse metadata
+ResponseEntity<ActorFilms> responseEntity = chatClient.prompt()
+    .user("Generate filmography for Tom Hanks")
+    .call()
+    .responseEntity(ActorFilms.class);
+```
+
+### Streaming Responses
+
+```java
+// Stream string content
+Flux<String> contentStream = chatClient.prompt()
+    .user("Write a long story")
+    .stream()
+    .content();
+
+// Stream ChatResponse
+Flux<ChatResponse> responseStream = chatClient.prompt()
+    .user("Write a long story")
+    .stream()
+    .chatResponse();
+```
+
+Streaming requirements:
+
+- Requires `spring-boot-starter-webflux` dependency
+- Tool calling within streaming is still blocking
+- Advisors perform non-blocking operations for streaming
+
+## Builder Default Configuration
+
+```java
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultSystem("You are a {role}")
+    .defaultUser("Default user context")
+
+    .defaultOptions(ChatOptions.builder()
+        .model("gpt-4o")
+        .temperature(0.7)
+        .build())
+
+    .defaultAdvisors(
+        MessageChatMemoryAdvisor.builder(chatMemory).build(),
+        new SimpleLoggerAdvisor())
+
+    .defaultTools(new DateTimeTools())
+    .defaultToolCallbacks(ToolCallbacks.from(new MyTools()))
+    .defaultFunctions("currentWeather")
+    .build();
+
+// Runtime override
+chatClient.prompt()
+    .system(s -> s.param("role", "pirate"))
+    .user("Tell me a joke")
+    .call()
+    .content();
+```
+
+## Multiple ChatClients for Different Models
+
+```java
+@Configuration
+public class ChatClientConfig {
+
+    @Bean
+    @Qualifier("openai")
+    public ChatClient openAiChatClient(OpenAiChatModel chatModel) {
+        return ChatClient.builder(chatModel)
+            .defaultOptions(OpenAiChatOptions.builder()
+                .model("gpt-4o")
+                .build())
+            .build();
+    }
+
+    @Bean
+    @Qualifier("anthropic")
+    public ChatClient anthropicChatClient(AnthropicChatModel chatModel) {
+        return ChatClient.builder(chatModel)
+            .defaultOptions(AnthropicChatOptions.builder()
+                .model("claude-sonnet-4-20250514")
+                .build())
+            .build();
+    }
+}
+
+// Inject with qualifier
+@RestController
+class MyController {
+    public MyController(
+        @Qualifier("openai") ChatClient openAiClient,
+        @Qualifier("anthropic") ChatClient anthropicClient
+    ) { ... }
+}
+```
+
+## OpenAI-Compatible Endpoints
+
+```java
+// Mutate API for different providers with OpenAI-compatible API
+OpenAiApi groqApi = baseOpenAiApi.mutate()
+    .baseUrl("https://api.groq.com/openai")
+    .apiKey(System.getenv("GROQ_API_KEY"))
+    .build();
+
+OpenAiChatModel groqModel = baseChatModel.mutate()
+    .openAiApi(groqApi)
+    .defaultOptions(OpenAiChatOptions.builder()
+        .model("llama3-70b-8192")
+        .temperature(0.5)
+        .build())
+    .build();
+
+ChatClient groqClient = ChatClient.create(groqModel);
+```
+
+## Template Renderer Customization
+
+```java
+// Custom delimiters (e.g., <placeholder> instead of {placeholder})
+chatClient.prompt()
+    .templateRenderer(StTemplateRenderer.builder()
+        .startDelimiterToken('<')
+        .endDelimiterToken('>')
+        .build())
+    .user(u -> u.text("Tell me about <topic>").param("topic", "AI"))
+    .call()
+    .content();
+```
+
+## Logging
+
+```java
+// Add SimpleLoggerAdvisor
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(new SimpleLoggerAdvisor())
+    .build();
+
+// Configure log level in application.yml
+// logging.level.org.springframework.ai.chat.client.advisor=DEBUG
+```
+
+## Important Notes
+
+- **Bug workaround**: Set `spring.http.client.factory=jdk` for Spring Boot 3.4+
+- **Thread safety**: `ChatClient` instances are thread-safe and should be reused
+- **Streaming stack**: Streaming requires WebFlux; non-streaming requires Servlet stack
+- **Tool calling**: Always blocking, even within streaming responses

--- a/spring-ai/references/tool-calling.md
+++ b/spring-ai/references/tool-calling.md
@@ -1,0 +1,309 @@
+# Tool/Function Calling
+
+## @Tool Annotation
+
+### Basic Usage
+
+```java
+class DateTimeTools {
+
+    @Tool(description = "Get the current date and time in the user's timezone")
+    String getCurrentDateTime() {
+        return LocalDateTime.now()
+            .atZone(LocaleContextHolder.getTimeZone().toZoneId())
+            .toString();
+    }
+
+    @Tool(description = "Set a user alarm for the given time")
+    void setAlarm(
+        @ToolParam(description = "Time in ISO-8601 format") String time
+    ) {
+        LocalDateTime alarmTime = LocalDateTime.parse(time, DateTimeFormatter.ISO_DATE_TIME);
+        alarmService.schedule(alarmTime);
+    }
+}
+```
+
+### @Tool Attributes
+
+| Attribute         | Default     | Description                                          |
+| ----------------- | ----------- | ---------------------------------------------------- |
+| `name`            | method name | Tool identifier used by the model                    |
+| `description`     | `""`        | How/when to call the tool (critical for model)       |
+| `returnDirect`    | `false`     | Return result directly to caller, not to model       |
+| `resultConverter` | default     | Custom `ToolCallResultConverter` implementation      |
+
+### @ToolParam Attributes
+
+| Attribute     | Default  | Description                        |
+| ------------- | -------- | ---------------------------------- |
+| `description` | `""`     | Parameter usage description        |
+| `required`    | `true`   | Whether parameter is mandatory     |
+
+Alternative annotations for parameter metadata: `@Nullable`, Jackson's `@JsonProperty`, Swagger's `@Schema`.
+
+## Registering Tools with ChatClient
+
+### Direct Tool Object
+
+```java
+ChatClient.create(chatModel)
+    .prompt("What day is tomorrow?")
+    .tools(new DateTimeTools())
+    .call()
+    .content();
+```
+
+### Default Tools (Builder)
+
+```java
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultTools(new DateTimeTools(), new WeatherTools())
+    .build();
+```
+
+### Tool Callbacks (Programmatic)
+
+```java
+ToolCallback[] callbacks = ToolCallbacks.from(new DateTimeTools());
+
+ChatClient.create(chatModel)
+    .prompt("What day is tomorrow?")
+    .toolCallbacks(callbacks)
+    .call()
+    .content();
+```
+
+### Tool Names (Dynamic Resolution from Beans)
+
+```java
+@Configuration
+class ToolConfig {
+    @Bean("currentWeather")
+    @Description("Get the weather in a location")
+    Function<WeatherRequest, WeatherResponse> currentWeather() {
+        return request -> weatherService.getWeather(request);
+    }
+}
+
+// Resolve by bean name
+ChatClient.create(chatModel)
+    .prompt("What's the weather in Seoul?")
+    .toolNames("currentWeather")
+    .call()
+    .content();
+```
+
+## ToolCallback Interface
+
+```java
+public interface ToolCallback {
+    ToolDefinition getToolDefinition();
+    ToolMetadata getToolMetadata();
+    String call(String toolInput);
+    String call(String toolInput, ToolContext toolContext);
+}
+```
+
+### Built-in Implementations
+
+| Implementation          | Source                                                |
+| ----------------------- | ----------------------------------------------------- |
+| `MethodToolCallback`    | From `@Tool` annotated methods                        |
+| `FunctionToolCallback`  | From `Function`, `Supplier`, `Consumer`, `BiFunction` |
+
+### FunctionToolCallback Builder
+
+```java
+ToolCallback toolCallback = FunctionToolCallback
+    .builder("currentWeather", new WeatherService())
+    .description("Get the weather in a location")
+    .inputType(WeatherRequest.class)
+    .build();
+```
+
+## Tool Context
+
+Pass application-level context to tools without exposing it to the model.
+
+```java
+class CustomerTools {
+
+    @Tool(description = "Retrieve customer information")
+    Customer getCustomerInfo(
+        Long id,
+        ToolContext toolContext
+    ) {
+        String tenantId = (String) toolContext.getContext().get("tenantId");
+        return customerRepository.findByIdAndTenant(id, tenantId);
+    }
+}
+
+// Pass context at call time
+chatClient.prompt()
+    .tools(new CustomerTools())
+    .toolContext(Map.of("tenantId", "acme"))
+    .user("Tell me about customer 42")
+    .call()
+    .content();
+```
+
+## Return Direct
+
+When `returnDirect = true`, the tool result goes directly to the caller instead of being sent back to the model for further processing.
+
+```java
+class CustomerTools {
+
+    @Tool(description = "Retrieve customer info", returnDirect = true)
+    Customer getCustomerInfo(Long id) {
+        return customerRepository.findById(id);
+    }
+}
+```
+
+## Tool Execution Approaches
+
+### Framework-Controlled (Default)
+
+The framework automatically executes tool calls and feeds results back to the model.
+
+```java
+// Default behavior — no special configuration needed
+chatClient.prompt()
+    .tools(new MyTools())
+    .user("What's the weather?")
+    .call()
+    .content();
+```
+
+### Advisor-Controlled
+
+```java
+var toolCallAdvisor = ToolCallAdvisor.builder()
+    .toolCallingManager(toolCallingManager)
+    .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 300)
+    .build();
+
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(toolCallAdvisor)
+    .build();
+```
+
+### User-Controlled (Manual Loop)
+
+```java
+ToolCallingChatOptions options = ToolCallingChatOptions.builder()
+    .toolCallbacks(toolCallbacks)
+    .internalToolExecutionEnabled(false)
+    .build();
+
+Prompt prompt = new Prompt("Your question", options);
+ChatResponse response = chatModel.call(prompt);
+
+while (response.hasToolCalls()) {
+    ToolExecutionResult result = toolCallingManager.executeToolCalls(prompt, response);
+    prompt = new Prompt(result.conversationHistory(), options);
+    response = chatModel.call(prompt);
+}
+```
+
+## Tool Argument Augmentation
+
+Capture additional model reasoning without modifying tool signatures.
+
+```java
+public record AgentThinking(
+    @ToolParam(description = "Your reasoning for calling this tool", required = true)
+    String innerThought,
+    @ToolParam(description = "Confidence level", required = false)
+    String confidence
+) {}
+
+AugmentedToolCallbackProvider<AgentThinking> provider =
+    AugmentedToolCallbackProvider.<AgentThinking>builder()
+        .toolObject(new MyTools())
+        .argumentType(AgentThinking.class)
+        .argumentConsumer(event -> {
+            log.info("Tool: {} | Reasoning: {}",
+                event.toolDefinition().name(),
+                event.arguments().innerThought());
+        })
+        .removeExtraArgumentsAfterProcessing(true)
+        .build();
+
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultToolCallbacks(provider)
+    .build();
+```
+
+## Error Handling
+
+### Global Exception Processor
+
+```java
+@Bean
+ToolExecutionExceptionProcessor toolErrorProcessor() {
+    // Return error message to model (default behavior)
+    return new DefaultToolExecutionExceptionProcessor(false);
+}
+
+// Or throw exceptions to halt processing
+@Bean
+ToolExecutionExceptionProcessor toolErrorProcessor() {
+    return new DefaultToolExecutionExceptionProcessor(true);
+}
+```
+
+Property: `spring.ai.tools.throw-exception-on-error` (default: `false`)
+
+## Key Interfaces
+
+### ToolDefinition
+
+```java
+public interface ToolDefinition {
+    String name();
+    String description();
+    String inputSchema(); // JSON Schema
+}
+```
+
+### ToolCallingManager
+
+```java
+public interface ToolCallingManager {
+    List<ToolDefinition> resolveToolDefinitions(ToolCallingChatOptions options);
+    ToolExecutionResult executeToolCalls(Prompt prompt, ChatResponse response);
+}
+```
+
+### ToolCallbackResolver Implementations
+
+| Resolver                         | Purpose                                   |
+| -------------------------------- | ----------------------------------------- |
+| `SpringBeanToolCallbackResolver` | Resolves Function/Supplier/Consumer beans |
+| `StaticToolCallbackResolver`     | From static ToolCallback lists            |
+| `DelegatingToolCallbackResolver` | Delegates to multiple resolvers           |
+
+## Utility Classes
+
+| Class                    | Purpose                                        |
+| ------------------------ | ---------------------------------------------- |
+| `ToolCallbacks`          | Generate `ToolCallback[]` from `@Tool` objects |
+| `ToolDefinitions`        | Build `ToolDefinition` from methods            |
+| `JsonSchemaGenerator`    | Auto-generate JSON schemas from signatures     |
+| `ToolCallingChatOptions` | Configure tool calling behavior                |
+
+## Limitations
+
+Method-based tools do NOT support:
+
+- `Optional`, `CompletableFuture`, `Future`
+- Reactive types (`Mono`, `Flux`, `Flow`)
+- Functional types (use function approach instead)
+
+Function-based tools do NOT support:
+
+- Primitive types
+- `Optional`, collections, async/reactive types

--- a/spring-ai/references/vector-store-rag.md
+++ b/spring-ai/references/vector-store-rag.md
@@ -1,0 +1,375 @@
+# Vector Store and RAG
+
+## Vector Store API
+
+### Core Interfaces
+
+```java
+// Read-only retrieval
+@FunctionalInterface
+public interface VectorStoreRetriever {
+    List<Document> similaritySearch(SearchRequest request);
+
+    default List<Document> similaritySearch(String query) {
+        return similaritySearch(SearchRequest.builder().query(query).build());
+    }
+}
+
+// Full read/write operations
+public interface VectorStore extends DocumentWriter, VectorStoreRetriever {
+    void add(List<Document> documents);
+    void delete(List<String> idList);
+    void delete(Filter.Expression filterExpression);
+    default void delete(String filterExpression) { ... }
+}
+```
+
+### Document Class
+
+```java
+Document document = new Document(
+    "Document content text",
+    Map.of("country", "Korea", "year", "2024", "topic", "spring-ai")
+);
+
+vectorStore.add(List.of(document));
+```
+
+### SearchRequest Builder
+
+```java
+SearchRequest request = SearchRequest.builder()
+    .query("How does Spring AI work?")
+    .topK(5)                            // Default: 4
+    .similarityThreshold(0.7)           // Default: 0.0 (accept all)
+    .filterExpression("topic == 'spring-ai'")
+    .build();
+
+List<Document> results = vectorStore.similaritySearch(request);
+```
+
+### Delete Operations
+
+```java
+// By document IDs
+vectorStore.delete(List.of(document.getId()));
+
+// By filter expression object
+Filter.Expression filter = new Filter.Expression(
+    Filter.ExpressionType.EQ,
+    new Filter.Key("country"),
+    new Filter.Value("Korea")
+);
+vectorStore.delete(filter);
+
+// By filter string
+vectorStore.delete("country == 'Korea'");
+```
+
+## Metadata Filtering
+
+### String Syntax (SQL-like)
+
+```java
+"country == 'Korea'"
+"genre == 'drama' && year >= 2020"
+"genre in ['comedy', 'documentary', 'drama']"
+"country == 'Korea' AND version == '1.0'"
+```
+
+### FilterExpressionBuilder (Programmatic)
+
+```java
+FilterExpressionBuilder b = new FilterExpressionBuilder();
+
+// Comparison operators: ==, !=, >, >=, <, <=
+Expression exp = b.eq("country", "Korea").build();
+
+// Logical operators: AND, OR
+Expression exp = b.and(
+    b.eq("genre", "drama"),
+    b.gte("year", 2020)
+).build();
+
+// IN operator
+Expression exp = b.in("genre", "drama", "documentary").build();
+
+// NOT operator
+Expression exp = b.not(b.lt("year", 2020)).build();
+
+// NULL operators
+Expression exp = b.isNull("year").build();
+Expression exp = b.isNotNull("year").build();
+```
+
+## Supported Vector Databases
+
+| Database             | Artifact                        |
+| -------------------- | ------------------------------- |
+| Azure Vector Search  | `spring-ai-azure-store`         |
+| Apache Cassandra     | `spring-ai-cassandra-store`     |
+| Chroma               | `spring-ai-chroma-store`        |
+| Elasticsearch        | `spring-ai-elasticsearch-store` |
+| Milvus               | `spring-ai-milvus-store`        |
+| MongoDB Atlas        | `spring-ai-mongodb-atlas-store` |
+| Neo4j                | `spring-ai-neo4j-store`         |
+| OpenSearch           | `spring-ai-opensearch-store`    |
+| PGVector (PostgreSQL)| `spring-ai-pgvector-store`      |
+| Pinecone             | `spring-ai-pinecone-store`      |
+| Qdrant               | `spring-ai-qdrant-store`        |
+| Redis                | `spring-ai-redis-store`         |
+| Weaviate             | `spring-ai-weaviate-store`      |
+| SimpleVectorStore    | `spring-ai-core` (in-memory)    |
+
+## Batching Strategy
+
+```java
+@Bean
+public BatchingStrategy batchingStrategy() {
+    return new TokenCountBatchingStrategy(
+        EncodingType.CL100K_BASE,  // Encoding type
+        8000,                      // Max input tokens
+        0.1                        // Reserve percentage (10%)
+    );
+}
+```
+
+## Document Ingestion
+
+```java
+@Service
+public class DocumentIngestionService {
+    private final VectorStore vectorStore;
+
+    public void ingestDocuments(Resource resource) {
+        // Read from JSON
+        JsonReader jsonReader = new JsonReader(
+            resource,
+            "price", "name", "shortDescription"
+        );
+        List<Document> documents = jsonReader.get();
+        vectorStore.add(documents);
+    }
+}
+```
+
+---
+
+## RAG (Retrieval Augmented Generation)
+
+### QuestionAnswerAdvisor (Simple RAG)
+
+Dependency:
+
+```xml
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-advisors-vector-store</artifactId>
+</dependency>
+```
+
+Basic usage:
+
+```java
+ChatClient chatClient = ChatClient.builder(chatModel)
+    .defaultAdvisors(
+        QuestionAnswerAdvisor.builder(vectorStore)
+            .searchRequest(SearchRequest.builder()
+                .similarityThreshold(0.7)
+                .topK(5)
+                .build())
+            .build())
+    .build();
+
+String answer = chatClient.prompt()
+    .user("What is Spring AI?")
+    .call()
+    .content();
+```
+
+Dynamic filter expressions at request time:
+
+```java
+String answer = chatClient.prompt()
+    .user("Tell me about Spring AI")
+    .advisors(a -> a.param(
+        QuestionAnswerAdvisor.FILTER_EXPRESSION,
+        "type == 'documentation'"))
+    .call()
+    .content();
+```
+
+Custom prompt template:
+
+```java
+PromptTemplate customTemplate = PromptTemplate.builder()
+    .renderer(StTemplateRenderer.builder()
+        .startDelimiterToken('<')
+        .endDelimiterToken('>')
+        .build())
+    .template("""
+        <query>
+        Context information is below.
+        ---------------------
+        <question_answer_context>
+        ---------------------
+        Given the context information and no prior knowledge, answer the query.
+        """)
+    .build();
+
+QuestionAnswerAdvisor qaAdvisor = QuestionAnswerAdvisor.builder(vectorStore)
+    .promptTemplate(customTemplate)
+    .build();
+```
+
+Required template placeholders: `query`, `question_answer_context`.
+
+### RetrievalAugmentationAdvisor (Advanced RAG)
+
+Dependency:
+
+```xml
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-rag</artifactId>
+</dependency>
+```
+
+#### Naive RAG
+
+```java
+Advisor ragAdvisor = RetrievalAugmentationAdvisor.builder()
+    .documentRetriever(VectorStoreDocumentRetriever.builder()
+        .vectorStore(vectorStore)
+        .similarityThreshold(0.5)
+        .build())
+    .build();
+
+String answer = chatClient.prompt()
+    .advisors(ragAdvisor)
+    .user("What is Spring AI?")
+    .call()
+    .content();
+```
+
+#### Advanced RAG with Query Transformation
+
+```java
+Advisor ragAdvisor = RetrievalAugmentationAdvisor.builder()
+    .queryTransformers(
+        RewriteQueryTransformer.builder()
+            .chatClientBuilder(chatClientBuilder.build().mutate())
+            .build())
+    .documentRetriever(VectorStoreDocumentRetriever.builder()
+        .vectorStore(vectorStore)
+        .similarityThreshold(0.5)
+        .build())
+    .build();
+```
+
+#### Allow Empty Context
+
+```java
+Advisor ragAdvisor = RetrievalAugmentationAdvisor.builder()
+    .documentRetriever(VectorStoreDocumentRetriever.builder()
+        .vectorStore(vectorStore)
+        .similarityThreshold(0.5)
+        .build())
+    .queryAugmenter(ContextualQueryAugmenter.builder()
+        .allowEmptyContext(true)
+        .build())
+    .build();
+```
+
+### VectorStoreDocumentRetriever
+
+```java
+DocumentRetriever retriever = VectorStoreDocumentRetriever.builder()
+    .vectorStore(vectorStore)
+    .similarityThreshold(0.73)
+    .topK(5)
+    .filterExpression(new FilterExpressionBuilder()
+        .eq("genre", "documentation")
+        .build())
+    .build();
+
+List<Document> documents = retriever.retrieve(new Query("What is Spring AI?"));
+```
+
+Dynamic filter with supplier (e.g., multi-tenant):
+
+```java
+DocumentRetriever retriever = VectorStoreDocumentRetriever.builder()
+    .vectorStore(vectorStore)
+    .filterExpression(() -> new FilterExpressionBuilder()
+        .eq("tenant", TenantContextHolder.getTenantIdentifier())
+        .build())
+    .build();
+```
+
+## Query Transformation Modules
+
+### CompressionQueryTransformer
+
+Compresses conversation history into a standalone query.
+
+```java
+QueryTransformer transformer = CompressionQueryTransformer.builder()
+    .chatClientBuilder(chatClientBuilder)
+    .build();
+```
+
+### RewriteQueryTransformer
+
+Rewrites verbose or ambiguous queries for better retrieval.
+
+```java
+QueryTransformer transformer = RewriteQueryTransformer.builder()
+    .chatClientBuilder(chatClientBuilder)
+    .build();
+```
+
+### TranslationQueryTransformer
+
+Translates queries to a target language (matching the embedding model language).
+
+```java
+QueryTransformer transformer = TranslationQueryTransformer.builder()
+    .chatClientBuilder(chatClientBuilder)
+    .targetLanguage("english")
+    .build();
+```
+
+### MultiQueryExpander
+
+Expands a single query into multiple semantically diverse variants.
+
+```java
+MultiQueryExpander expander = MultiQueryExpander.builder()
+    .chatClientBuilder(chatClientBuilder)
+    .numberOfQueries(3)
+    .includeOriginal(true)
+    .build();
+```
+
+## Query Augmentation
+
+### ContextualQueryAugmenter
+
+Augments the user query with retrieved document context before sending to the model.
+
+```java
+QueryAugmenter augmenter = ContextualQueryAugmenter.builder()
+    .allowEmptyContext(false)  // Default: disallow empty context
+    .build();
+```
+
+## Best Practices
+
+- Set `similarityThreshold` to 0.5-0.8 in production — 0.0 returns irrelevant results
+- Use `topK` of 3-10 depending on context window size and cost constraints
+- Use metadata filtering for multi-tenant isolation
+- Use `CompressionQueryTransformer` for multi-turn conversations to produce standalone queries
+- Use `RewriteQueryTransformer` when user queries are verbose or ambiguous
+- Monitor retrieval quality — poor retrieval leads to hallucinated answers regardless of model quality
+- Use low temperature (0.0) for query transformation to get deterministic results


### PR DESCRIPTION
## 요약

- Spring AI 애플리케이션 개발을 위한 새로운 스킬을 추가합니다
- ChatClient 설정, Tool/Function Calling, Prompt Template, Vector Store, RAG, Advisors API, MCP 통합, Multi-model 라우팅, 에이전트 구축, 에러 핸들링 등 핵심 패턴을 포함합니다
- Spring AI 공식 문서의 최신 API를 반영하였습니다

## 추가된 파일

- `spring-ai/SKILL.md` — Spring AI 핵심 규칙 및 패턴 (10개 섹션)
- `spring-ai/references/chatclient-patterns.md` — ChatClient fluent API, 스트리밍, 구조화 출력, 멀티 모델 설정
- `spring-ai/references/tool-calling.md` — @Tool 어노테이션, ToolCallback, 실행 방식, 에러 핸들링
- `spring-ai/references/vector-store-rag.md` — VectorStore API, 지원 DB 목록, RAG Advisor, 쿼리 변환

Part of #40 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)