### PR TITLE
fix: compatibility 필드를 Agent Skills Specification에 맞게 수정

### DIFF
--- a/api-design/SKILL.md
+++ b/api-design/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # REST API Design Rules

--- a/caching/SKILL.md
+++ b/caching/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Caching Rules

--- a/chaos-engineering/SKILL.md
+++ b/chaos-engineering/SKILL.md
@@ -13,11 +13,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Skill: Chaos Engineering

--- a/ci-cd/SKILL.md
+++ b/ci-cd/SKILL.md
@@ -8,11 +8,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires GitHub Actions (GitHub repository)
 ---
 
 # CI/CD Pipeline Rules

--- a/clean-architecture/SKILL.md
+++ b/clean-architecture/SKILL.md
@@ -13,11 +13,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Clean Architecture / Hexagonal Architecture Rules

--- a/cloud-native/SKILL.md
+++ b/cloud-native/SKILL.md
@@ -16,11 +16,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Cloud Native / Twelve-Factor App Rules

--- a/code-quality/SKILL.md
+++ b/code-quality/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 # Code Quality and Design Principles
 

--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -12,11 +12,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 # Code Review Rules
 

--- a/concurrency/SKILL.md
+++ b/concurrency/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # JVM Concurrency Rules

--- a/data-migration/SKILL.md
+++ b/data-migration/SKILL.md
@@ -15,11 +15,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Data Migration and ETL Patterns

--- a/database/SKILL.md
+++ b/database/SKILL.md
@@ -11,11 +11,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Database Rules

--- a/ddd/SKILL.md
+++ b/ddd/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Domain-Driven Design (DDD) Skill

--- a/distributed-systems/SKILL.md
+++ b/distributed-systems/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Distributed Systems Patterns

--- a/dockerfile/SKILL.md
+++ b/dockerfile/SKILL.md
@@ -11,11 +11,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires Docker daemon
 ---
 
 # Dockerfile Rules

--- a/error-handling/SKILL.md
+++ b/error-handling/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 # Error Handling Rules
 

--- a/exposed/SKILL.md
+++ b/exposed/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Exposed ORM Rules

--- a/feature-flag/SKILL.md
+++ b/feature-flag/SKILL.md
@@ -14,11 +14,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Feature Flag and Progressive Delivery Rules

--- a/git-workflow/SKILL.md
+++ b/git-workflow/SKILL.md
@@ -12,11 +12,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Git Workflow Rules

--- a/gitops-argocd/SKILL.md
+++ b/gitops-argocd/SKILL.md
@@ -10,11 +10,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires Argo CD CLI and Kubernetes cluster access
 ---
 
 # GitOps with Argo CD Rules

--- a/gradle-convention/SKILL.md
+++ b/gradle-convention/SKILL.md
@@ -12,11 +12,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires Gradle or Gradle Wrapper
 ---
 
 # Gradle Convention Rules

--- a/graphql/SKILL.md
+++ b/graphql/SKILL.md
@@ -16,11 +16,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # GraphQL API Design and Implementation Rules

--- a/grpc/SKILL.md
+++ b/grpc/SKILL.md
@@ -15,11 +15,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires protoc (Protocol Buffers compiler)
 ---
 
 # gRPC and Protocol Buffers Rules

--- a/helm-workflow/SKILL.md
+++ b/helm-workflow/SKILL.md
@@ -10,11 +10,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires Helm CLI
 ---
 
 # Helm Workflow Rules

--- a/http-client/SKILL.md
+++ b/http-client/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 # External API Client Rules
 

--- a/incident-response/SKILL.md
+++ b/incident-response/SKILL.md
@@ -12,11 +12,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Incident Response Rules

--- a/index/SKILL.md
+++ b/index/SKILL.md
@@ -10,11 +10,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Skill Routing Index

--- a/java-convention/SKILL.md
+++ b/java-convention/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Java Convention Rules

--- a/java-kotlin-interop/SKILL.md
+++ b/java-kotlin-interop/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Java-Kotlin Interoperability Rules

--- a/jvm-performance/SKILL.md
+++ b/jvm-performance/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # JVM Performance Optimization

--- a/k8s-workflow/SKILL.md
+++ b/k8s-workflow/SKILL.md
@@ -12,11 +12,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires kubectl and Kubernetes cluster access
 ---
 
 # Kubernetes Workflow Rules

--- a/karpenter-workflow/SKILL.md
+++ b/karpenter-workflow/SKILL.md
@@ -10,11 +10,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires kubectl and Kubernetes cluster with Karpenter
 ---
 
 # Karpenter Workflow Guide

--- a/kotlin-convention/SKILL.md
+++ b/kotlin-convention/SKILL.md
@@ -12,11 +12,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Kotlin Convention Rules

--- a/load-testing/SKILL.md
+++ b/load-testing/SKILL.md
@@ -9,11 +9,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires k6 or Gatling
 ---
 
 # Load Testing Rules

--- a/logging/SKILL.md
+++ b/logging/SKILL.md
@@ -12,11 +12,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Logging Rules

--- a/messaging/SKILL.md
+++ b/messaging/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 # Messaging Rules
 

--- a/microservices/SKILL.md
+++ b/microservices/SKILL.md
@@ -11,11 +11,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Microservices Architecture Pattern Rules

--- a/monitoring/SKILL.md
+++ b/monitoring/SKILL.md
@@ -10,11 +10,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 # Monitoring and Observability Rules
 

--- a/object-oriented-design/SKILL.md
+++ b/object-oriented-design/SKILL.md
@@ -12,11 +12,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Object-Oriented Design Principles (SOLID Advanced)

--- a/openapi-spec/SKILL.md
+++ b/openapi-spec/SKILL.md
@@ -10,11 +10,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # OpenAPI Specification Rules

--- a/pdf-handling/SKILL.md
+++ b/pdf-handling/SKILL.md
@@ -8,11 +8,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires pdfplumber or PyMuPDF
 ---
 
 # PDF File Handling Rules

--- a/prompt-engineering/SKILL.md
+++ b/prompt-engineering/SKILL.md
@@ -10,11 +10,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Prompt Engineering Rules

--- a/react-convention/SKILL.md
+++ b/react-convention/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # React/Next.js Coding Conventions

--- a/resume-writing/SKILL.md
+++ b/resume-writing/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 # Developer Resume Rules
 

--- a/secrets-management/SKILL.md
+++ b/secrets-management/SKILL.md
@@ -10,11 +10,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: May require vault CLI or cloud provider CLI
 ---
 
 # Secrets Management Rules

--- a/security/SKILL.md
+++ b/security/SKILL.md
@@ -10,11 +10,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 # Security Rules
 

--- a/spring-ai/SKILL.md
+++ b/spring-ai/SKILL.md
@@ -14,11 +14,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Spring AI Core Rules

--- a/spring-framework/SKILL.md
+++ b/spring-framework/SKILL.md
@@ -15,11 +15,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Spring Framework Core Rules

--- a/system-design/SKILL.md
+++ b/system-design/SKILL.md
@@ -13,11 +13,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # System Design Interview Patterns

--- a/technical-documentation/SKILL.md
+++ b/technical-documentation/SKILL.md
@@ -9,11 +9,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Technical Documentation Guide

--- a/terraform-workflow/SKILL.md
+++ b/terraform-workflow/SKILL.md
@@ -10,11 +10,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires Terraform CLI
 ---
 # Terraform Workflow Rules
 

--- a/testing/SKILL.md
+++ b/testing/SKILL.md
@@ -10,11 +10,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 # BDD-Style Unit Test Rules
 

--- a/troubleshooting/SKILL.md
+++ b/troubleshooting/SKILL.md
@@ -13,11 +13,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # Troubleshooting Rules

--- a/typescript-convention/SKILL.md
+++ b/typescript-convention/SKILL.md
@@ -10,11 +10,6 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
 ---
 
 # TypeScript Coding Conventions

--- a/weather/SKILL.md
+++ b/weather/SKILL.md
@@ -9,11 +9,7 @@ metadata:
   author: iceflower
   version: "1.0"
   last-reviewed: "2026-03"
-compatibility:
-  - OpenCode
-  - Claude Code
-  - Codex
-  - Antigravity
+compatibility: Requires internet access for KMA/AccuWeather APIs
 ---
 
 # Weather Information Rules


### PR DESCRIPTION
## Summary

- 환경 요구사항이 없는 41개 스킬에서 배열 형식 `compatibility` 필드 제거
- 환경 요구사항이 있는 13개 스킬의 `compatibility`를 스펙 준수 문자열로 변환
- `license`, `metadata` 필드는 이미 올바르게 존재하여 변경 없음

### compatibility 변환 대상 (13개)

| 스킬 | compatibility |
|------|--------------|
| `ci-cd` | Requires GitHub Actions (GitHub repository) |
| `dockerfile` | Requires Docker daemon |
| `gitops-argocd` | Requires Argo CD CLI and Kubernetes cluster access |
| `gradle-convention` | Requires Gradle or Gradle Wrapper |
| `grpc` | Requires protoc (Protocol Buffers compiler) |
| `helm-workflow` | Requires Helm CLI |
| `k8s-workflow` | Requires kubectl and Kubernetes cluster access |
| `karpenter-workflow` | Requires kubectl and Kubernetes cluster with Karpenter |
| `load-testing` | Requires k6 or Gatling |
| `pdf-handling` | Requires pdfplumber or PyMuPDF |
| `secrets-management` | May require vault CLI or cloud provider CLI |
| `terraform-workflow` | Requires Terraform CLI |
| `weather` | Requires internet access for KMA/AccuWeather APIs |

## Test plan

- [x] 환경 요구사항 없는 스킬에서 `compatibility` 필드가 제거되었는지 확인
- [x] 환경 요구사항 있는 13개 스킬에 문자열 형식 `compatibility`가 존재하는지 확인
- [x] frontmatter YAML 파싱 오류 없는지 확인

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)