### PR TITLE
fix: lint_frontmatter.py를 Agent Skills Specification에 맞게 수정

### DIFF
--- a/scripts/lint_frontmatter.py
+++ b/scripts/lint_frontmatter.py
@@ -19,9 +19,8 @@ from pathlib import Path
 
 import yaml
 
-REQUIRED_TOP_LEVEL = {"name", "description", "license", "metadata", "compatibility"}
+REQUIRED_TOP_LEVEL = {"name", "description", "license", "metadata"}
 REQUIRED_METADATA = {"author", "version", "last-reviewed"}
-REQUIRED_COMPATIBILITY = {"OpenCode", "Claude Code", "Codex", "Antigravity"}
 
 
 def parse_frontmatter(path: Path) -> dict | None:
@@ -71,19 +70,10 @@ def validate(path: Path) -> list[str]:
                 f"missing metadata fields: {', '.join(sorted(missing_meta))}"
             )
 
-    # compatibility required values
+    # compatibility (optional, string per Agent Skills Specification)
     compat = fm.get("compatibility")
-    if compat is None:
-        pass  # already reported above
-    elif not isinstance(compat, list):
-        errors.append("'compatibility' must be a list")
-    else:
-        compat_set = set(compat)
-        missing_compat = REQUIRED_COMPATIBILITY - compat_set
-        if missing_compat:
-            errors.append(
-                f"missing compatibility values: {', '.join(sorted(missing_compat))}"
-            )
+    if compat is not None and not isinstance(compat, str):
+        errors.append("'compatibility' must be a string (not a list)")
 
     return errors
 


### PR DESCRIPTION
## Summary

- `compatibility` 필드를 required에서 optional로 변경
- `compatibility` 타입을 list에서 string으로 변경 (Agent Skills Specification 준수)
- `REQUIRED_COMPATIBILITY` 고정값 세트 제거

### 배경

Agent Skills Specification에서 `compatibility`는:
- Optional 필드 (max 500자 문자열)
- 환경 요구사항을 기술하는 용도
- "Most skills do not need the `compatibility` field"

기존 lint 스크립트는 `compatibility`를 필수 리스트로 강제하고 있어, PR #57 이후의 모든 PR에서 CI가 실패하는 상황이었습니다.

## Test plan

- [x] 스크립트가 compatibility 없는 스킬을 허용하는지 확인
- [x] 스크립트가 compatibility 문자열을 허용하는지 확인
- [x] 스크립트가 compatibility 리스트를 거부하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)