### PR TITLE
feat(spring-ai): update skill for Spring AI 2.x + Spring Boot 4.0

### DIFF
--- a/spring-ai/README.md
+++ b/spring-ai/README.md
@@ -27,6 +27,7 @@ spring-ai/
 └── references/
     ├── advanced-rag-agents.md
     ├── chatclient-patterns.md
+    ├── migration-2x.md
     ├── tool-calling.md
     └── vector-store-rag.md
 ```

--- a/spring-ai/SKILL.md
+++ b/spring-ai/SKILL.md
@@ -243,7 +243,7 @@ ChatClient chatClient = ChatClient.builder(chatModel)
 | `ReReadingAdvisor`              | RE2 technique for better reasoning      |
 | `SimpleLoggerAdvisor`           | Request/response logging                |
 
-> **Deprecation note (2.x):** `MessageChatMemoryAdvisor.disableMemory()` is deprecated. Use `disableInternalConversationHistory()` instead.
+> **Deprecation note (2.x):** `ChatClient.disableMemory()` is deprecated. Use `disableInternalConversationHistory()` instead.
 
 ---
 

--- a/spring-ai/SKILL.md
+++ b/spring-ai/SKILL.md
@@ -15,11 +15,22 @@ description: >-
 license: MIT
 metadata:
   author: iceflower
-  version: "2.0"
+  version: "2.1"
   last-reviewed: "2026-04"
 ---
 
 # Spring AI Core Rules
+
+## Platform Requirements
+
+| Requirement           | Version                          |
+| --------------------- | -------------------------------- |
+| Spring AI             | 2.0.x (latest: 2.0.0-M4)         |
+| Spring Boot           | 4.0+ (Spring Framework 7.0)      |
+| JDK                   | 17+ (JDK 25 LTS recommended)     |
+| Jackson               | 3 (`tools.jackson` package)      |
+
+> Jackson 3 uses `tools.jackson` package namespace instead of `com.fasterxml.jackson`. Ensure all serialization dependencies align.
 
 ## 1. ChatClient Configuration
 
@@ -33,6 +44,7 @@ metadata:
 - Use `.call()` for synchronous responses, `.stream()` for reactive `Flux` responses
 - Use `.entity(Class<T>)` for structured output — Spring AI handles JSON schema generation
 - Always configure `spring.ai.retry` properties for production resilience
+- Always configure `spring.ai.openai.chat.options.temperature` explicitly — no default value in 2.x
 
 ### ChatClient Creation
 
@@ -60,7 +72,7 @@ class MyController {
 - Use `@Tool` annotation for declarative tool definitions — method name becomes tool name by default
 - Always provide descriptive `description` — the model uses it to decide when to call the tool
 - Use `@ToolParam(description = "...")` for parameter descriptions — improves model accuracy
-- Register tools via `.tools(new MyTools())` on ChatClient or `.defaultTools()` on builder
+- Register tools via `.tools(new MyTools())` on ChatClient or `.defaultTools()` on builder — `.defaultFunctions()` is removed in 2.x; both methods use `ToolCallback` internally
 - Use `ToolContext` to pass application context (tenant ID, user info) without exposing to the model
 - Tool methods must not return reactive types (`Mono`, `Flux`) — tool calling is synchronous
 - Set `returnDirect = true` on `@Tool` when the tool result should go directly to the user
@@ -231,6 +243,8 @@ ChatClient chatClient = ChatClient.builder(chatModel)
 | `ReReadingAdvisor`              | RE2 technique for better reasoning      |
 | `SimpleLoggerAdvisor`           | Request/response logging                |
 
+> **Deprecation note (2.x):** `MessageChatMemoryAdvisor.disableMemory()` is deprecated. Use `disableInternalConversationHistory()` instead.
+
 ---
 
 ## 7. MCP (Model Context Protocol) Integration
@@ -258,6 +272,8 @@ Spring AI provides MCP integration through Boot starters for both client and ser
 ```
 
 ### Server Annotations
+
+> Annotations (`@McpTool`, `@McpResource`, `@McpPrompt`) are provided by `spring-ai-mcp-annotations` artifact — included transitively by the server starters.
 
 ```java
 @McpTool          // Expose tools to MCP clients
@@ -300,7 +316,7 @@ public class MultiModelConfig {
     public ChatClient fastClient(OpenAiChatModel openAiModel) {
         return ChatClient.builder(openAiModel)
             .defaultOptions(OpenAiChatOptions.builder()
-                .model("gpt-4o-mini")
+                .model("gpt-5-mini")
                 .temperature(0.3)
                 .build())
             .build();
@@ -311,7 +327,7 @@ public class MultiModelConfig {
     public ChatClient powerfulClient(AnthropicChatModel anthropicModel) {
         return ChatClient.builder(anthropicModel)
             .defaultOptions(AnthropicChatOptions.builder()
-                .model("claude-sonnet-4-20250514")
+                .model("claude-sonnet-4-5-20250929")
                 .build())
             .build();
     }
@@ -433,6 +449,8 @@ ToolExecutionExceptionProcessor toolErrorProcessor() {
 - Hardcoding API keys — use `spring.ai.<provider>.api-key` from environment variables
 - Returning JPA entities from `@Tool` methods — use simple DTOs or Strings
 - Blocking the event loop with tool calls in WebFlux — tool calling is inherently blocking
+- Using setter-style `ChatOptions` (e.g., `new AnthropicChatOptions()`) — use builder pattern in 2.x
+- Relying on default temperature — must be explicitly configured in 2.x
 
 ---
 
@@ -448,3 +466,4 @@ ToolExecutionExceptionProcessor toolErrorProcessor() {
 - For @Tool annotation usage, ToolCallback interface, and migration patterns, see [references/tool-calling.md](references/tool-calling.md)
 - For vector store patterns, supported databases, and basic RAG implementation, see [references/vector-store-rag.md](references/vector-store-rag.md)
 - For advanced RAG (query rewriting, hybrid search, reranking, agentic RAG), agent frameworks, and model evaluation, see [references/advanced-rag-agents.md](references/advanced-rag-agents.md)
+- For migration from Spring AI 1.x to 2.x, see [references/migration-2x.md](references/migration-2x.md)

--- a/spring-ai/references/advanced-rag-agents.md
+++ b/spring-ai/references/advanced-rag-agents.md
@@ -347,6 +347,17 @@ public class HumanInTheLoopAgent {
 }
 ```
 
+#### Configure Thinking Level for Supported Models (Spring AI 2.x)
+
+```java
+// Configure thinking level for supported models (Spring AI 2.x)
+GoogleGenAiChatOptions options = GoogleGenAiChatOptions.builder()
+    .thinkingLevel(ThinkingLevel.HIGH)
+    .build();
+```
+
+> Spring AI 2.x supports `ThinkingLevel` configuration for Google GenAI models.
+
 ### Agent Memory Patterns
 
 ```java
@@ -376,7 +387,22 @@ ChatClient clientWithStructuredMemory = ChatClient.builder(chatModel)
         Always check preferences before making recommendations.
         """)
     .build();
+
+// Persistent: Redis-backed memory (Spring AI 2.x)
+@Configuration
+class RedisMemoryConfig {
+    @Bean
+    ChatClient clientWithPersistentMemory(ChatClient.Builder builder, ChatMemoryRepository redisRepo) {
+        return builder
+            .defaultAdvisors(
+                MessageChatMemoryAdvisor.builder(redisRepo).build()
+            )
+            .build();
+    }
+}
 ```
+
+> Spring AI 2.x includes `RedisChatMemoryRepository` via Spring Boot starter for persistent, distributed conversation storage.
 
 ### Agent Guardrails
 

--- a/spring-ai/references/chatclient-patterns.md
+++ b/spring-ai/references/chatclient-patterns.md
@@ -189,8 +189,8 @@ ChatClient chatClient = ChatClient.builder(chatModel)
     .defaultSystem("You are a {role}")
     .defaultUser("Default user context")
 
-    .defaultOptions(ChatOptions.builder()
-        .model("gpt-4o")
+    .defaultOptions(OpenAiChatOptions.builder()
+        .model("gpt-5-mini")
         .temperature(0.7)
         .build())
 

--- a/spring-ai/references/chatclient-patterns.md
+++ b/spring-ai/references/chatclient-patterns.md
@@ -294,8 +294,53 @@ ChatClient chatClient = ChatClient.builder(chatModel)
 // logging.level.org.springframework.ai.chat.client.advisor=DEBUG
 ```
 
+## Native Structured Output
+
+```java
+// Enable native structured output for supported models (OpenAI, Ollama, Mistral AI)
+ActorFilms films = chatClient.prompt()
+    .advisors(AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT)
+    .user("Generate filmography for Tom Hanks")
+    .call()
+    .entity(ActorFilms.class);
+
+// Dynamically disable at request time
+chatClient.prompt()
+    .advisors(AdvisorParams.DISABLE_NATIVE_STRUCTURED_OUTPUT)
+    .user("...")
+    .call()
+    .entity(ActorFilms.class);
+```
+
+## Spring Boot 4.0 HTTP Client Integration
+
+```java
+// Configure HTTP client with Spring Boot 4.0 patterns
+HttpClientSettings settings = HttpClientSettings.defaults()
+    .withConnectTimeout(Duration.ofSeconds(10))
+    .withReadTimeout(Duration.ofSeconds(30));
+
+RestClient.Builder restClientBuilder = RestClient.builder()
+    .requestFactory(ClientHttpRequestFactoryBuilder.detect().build(settings));
+
+OpenAiApi api = OpenAiApi.builder()
+    .apiKey(System.getenv("OPENAI_API_KEY"))
+    .baseUrl("https://api.openai.com")
+    .completionsPath("/chat/completions")
+    .restClientBuilder(restClientBuilder)
+    .build();
+
+OpenAiChatModel chatModel = OpenAiChatModel.builder()
+    .openAiApi(api)
+    .build();
+```
+
 ## Important Notes
 
+- **Jackson 3**: Spring AI 2.x uses Jackson 3 (`tools.jackson` package). If you have custom Jackson serializers/deserializers for structured output, update imports from `com.fasterxml.jackson` to `tools.jackson`.
+- **Native Structured Output**: Use `AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT` for models that support it (OpenAI, Ollama, Mistral AI) — avoids JSON schema indirection.
+- **No default temperature**: Spring AI 2.x no longer sets a default temperature. Always configure `temperature` in `ChatOptions` or via `spring.ai.<provider>.chat.options.temperature`.
+- **Builder-only ChatOptions**: All provider ChatOptions (AnthropicChatOptions, AzureOpenAiChatOptions, BedrockChatOptions, etc.) use builder pattern in 2.x. Setter-style construction is removed.
 - **Bug workaround**: Set `spring.http.client.factory=jdk` for Spring Boot 3.4+
 - **Thread safety**: `ChatClient` instances are thread-safe and should be reused
 - **Streaming stack**: Streaming requires WebFlux; non-streaming requires Servlet stack

--- a/spring-ai/references/chatclient-patterns.md
+++ b/spring-ai/references/chatclient-patterns.md
@@ -350,7 +350,6 @@ OpenAiChatModel chatModel = OpenAiChatModel.builder()
 - **Native Structured Output**: Use `AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT` for models that support it (OpenAI, Ollama, Mistral AI) — avoids JSON schema indirection.
 - **No default temperature**: Spring AI 2.x no longer sets a default temperature. Always configure `temperature` in `ChatOptions` or via `spring.ai.<provider>.chat.options.temperature`.
 - **Builder-only ChatOptions**: All provider ChatOptions (AnthropicChatOptions, AzureOpenAiChatOptions, BedrockChatOptions, etc.) use builder pattern in 2.x. Setter-style construction is removed.
-- **Bug workaround**: Set `spring.http.client.factory=jdk` for Spring Boot 3.4+
 - **Thread safety**: `ChatClient` instances are thread-safe and should be reused
 - **Streaming stack**: Streaming requires WebFlux; non-streaming requires Servlet stack
 - **Tool calling**: Always blocking, even within streaming responses

--- a/spring-ai/references/chatclient-patterns.md
+++ b/spring-ai/references/chatclient-patterns.md
@@ -200,7 +200,7 @@ ChatClient chatClient = ChatClient.builder(chatModel)
 
     .defaultTools(new DateTimeTools())
     .defaultToolCallbacks(ToolCallbacks.from(new MyTools()))
-    .defaultFunctions("currentWeather")
+    .defaultToolNames("currentWeather")
     .build();
 
 // Runtime override
@@ -232,7 +232,7 @@ public class ChatClientConfig {
     public ChatClient anthropicChatClient(AnthropicChatModel chatModel) {
         return ChatClient.builder(chatModel)
             .defaultOptions(AnthropicChatOptions.builder()
-                .model("claude-sonnet-4-20250514")
+                .model("claude-sonnet-4-5-20250929")
                 .build())
             .build();
     }

--- a/spring-ai/references/chatclient-patterns.md
+++ b/spring-ai/references/chatclient-patterns.md
@@ -251,16 +251,25 @@ class MyController {
 ## OpenAI-Compatible Endpoints
 
 ```java
-// Mutate API for different providers with OpenAI-compatible API
-OpenAiApi groqApi = baseOpenAiApi.mutate()
+// Create base OpenAI API and mutate for different providers
+OpenAiApi baseApi = OpenAiApi.builder()
+    .apiKey(System.getenv("OPENAI_API_KEY"))
+    .build();
+
+OpenAiChatModel baseModel = OpenAiChatModel.builder()
+    .openAiApi(baseApi)
+    .build();
+
+// Mutate for Groq (OpenAI-compatible API)
+OpenAiApi groqApi = baseApi.mutate()
     .baseUrl("https://api.groq.com/openai")
     .apiKey(System.getenv("GROQ_API_KEY"))
     .build();
 
-OpenAiChatModel groqModel = baseChatModel.mutate()
+OpenAiChatModel groqModel = baseModel.mutate()
     .openAiApi(groqApi)
     .defaultOptions(OpenAiChatOptions.builder()
-        .model("llama3-70b-8192")
+        .model("llama-3.3-70b-versatile")
         .temperature(0.5)
         .build())
     .build();

--- a/spring-ai/references/migration-2x.md
+++ b/spring-ai/references/migration-2x.md
@@ -7,7 +7,7 @@
 | Spring Boot | 3.x | **4.0+** (Spring Framework 7.0) |
 | JDK | 17+ | 17+ (JDK 25 LTS recommended) |
 | Jackson | **Jackson 2** (`com.fasterxml.jackson`) | **Jackson 3** (`tools.jackson`) |
-| Spring AI BOM | `1.x.x` | `2.0.0-M4+` |
+| Spring AI BOM | `1.1.x` | `2.0.0-M4+` |
 
 ---
 

--- a/spring-ai/references/migration-2x.md
+++ b/spring-ai/references/migration-2x.md
@@ -1,0 +1,240 @@
+# Migration Guide: Spring AI 1.x → 2.x
+
+## Platform Requirements
+
+| Component | 1.x | 2.x |
+|-----------|-----|-----|
+| Spring Boot | 3.x | **4.0+** (Spring Framework 7.0) |
+| JDK | 17+ | 17+ (JDK 25 LTS recommended) |
+| Jackson | **Jackson 2** (`com.fasterxml.jackson`) | **Jackson 3** (`tools.jackson`) |
+| Spring AI BOM | `1.x.x` | `2.0.0-M4+` |
+
+---
+
+## 1. FunctionCallback → ToolCallback API
+
+### API Mapping
+
+| 1.x (Deprecated) | 2.x (Current) |
+|-----------------|---------------|
+| `FunctionCallback` | `ToolCallback` |
+| `FunctionCallback.builder().function()` | `FunctionToolCallback.builder()` |
+| `FunctionCallback.builder().method()` | `MethodToolCallback.builder()` |
+| `FunctionCallingOptions` | `ToolCallingChatOptions` |
+| `ChatClient.builder().defaultFunctions()` | `ChatClient.builder().defaultTools()` |
+| `ChatClient.functions()` | `ChatClient.tools()` |
+| `FunctionCallingOptions.builder().functions()` | `ToolCallingChatOptions.builder().toolNames()` |
+| `FunctionCallingOptions.builder().functionCallbacks()` | `ToolCallingChatOptions.builder().toolCallbacks()` |
+
+### Example Migration
+
+```java
+// Before (1.x)
+FunctionCallback weatherCallback = FunctionCallback.builder()
+    .function("getCurrentWeather", new WeatherService())
+    .build();
+
+chatClient.prompt()
+    .functionCallbacks(weatherCallback)
+    .call()
+    .content();
+
+// After (2.x)
+ToolCallback weatherCallback = FunctionToolCallback
+    .builder("getCurrentWeather", new WeatherService())
+    .description("Get current weather for a city")
+    .inputType(WeatherRequest.class)
+    .build();
+
+chatClient.prompt()
+    .tools(weatherCallback)
+    .call()
+    .content();
+```
+
+---
+
+## 2. MCP Annotations Package Relocation
+
+### Package Change
+
+```java
+// Before (1.x) — external community library
+import org.springaicommunity.mcp.annotation.McpTool;
+import org.springaicommunity.mcp.annotation.McpToolParam;
+import org.springaicommunity.mcp.annotation.McpProgressToken;
+
+// After (2.x) — Spring AI core module
+import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.ai.mcp.annotation.McpProgressToken;
+```
+
+### Dependency Change
+
+```xml
+<!-- Before (1.x) -->
+<dependency>
+    <groupId>org.springaicommunity</groupId>
+    <artifactId>mcp-annotations</artifactId>
+</dependency>
+
+<!-- After (2.x) -->
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-mcp-annotations</artifactId>
+</dependency>
+```
+
+### Transport Module Relocation
+
+- Maven Group ID: `io.modelcontextprotocol.sdk` → `org.springframework.ai`
+- Package: `io.modelcontextprotocol.server.transport` → `org.springframework.ai.mcp.server.webmvc.transport`
+- Using Spring Boot starters (`spring-ai-starter-mcp-server*`) handles this automatically.
+
+---
+
+## 3. Jackson 2 → Jackson 3
+
+Spring AI 2.x uses Jackson 3, aligned with Spring Boot 4.0.
+
+### Import Changes
+
+```java
+// Before (Jackson 2)
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+// After (Jackson 3)
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.annotation.JsonProperty;
+```
+
+### Impact Areas
+
+- Custom `@Tool` method return types with Jackson annotations
+- Structured output entity classes with Jackson annotations
+- Custom JSON serializers/deserializers
+- `ObjectMapper` beans (may need explicit Jackson 3 configuration)
+
+---
+
+## 4. Default Temperature Removed
+
+Spring AI 2.x no longer provides a default `temperature` value.
+
+```yaml
+# Before (1.x) — temperature defaulted to 0.7
+spring:
+  ai:
+    openai:
+      chat:
+        options:
+          # temperature not set — defaulted to 0.7
+
+# After (2.x) — must be explicit
+spring:
+  ai:
+    openai:
+      chat:
+        options:
+          temperature: 0.7  # required if you want non-provider-default
+```
+
+---
+
+## 5. ChatOptions Builder Pattern
+
+All provider ChatOptions now require builder pattern in 2.x.
+
+```java
+// Before (1.x) — setter style (removed in 2.x)
+AnthropicChatOptions options = new AnthropicChatOptions();
+options.setTemperature(0.7);
+options.setModel("claude-3-sonnet-20240229");
+
+// After (2.x) — builder only
+AnthropicChatOptions options = AnthropicChatOptions.builder()
+    .temperature(0.7)
+    .model("claude-sonnet-4-5-20250929")
+    .build();
+```
+
+Affected classes: `AnthropicChatOptions`, `AzureOpenAiChatOptions`, `BedrockChatOptions`, `DeepSeekChatOptions`, `MistralAiChatOptions`, `MiniMaxChatOptions`.
+
+---
+
+## 6. Renamed Methods
+
+### ChatClient
+
+```java
+// Before (1.x)
+chatClient.disableMemory()
+
+// After (2.x)
+chatClient.disableInternalConversationHistory()
+```
+
+The old method is provided as a deprecated shim for backward compatibility.
+
+---
+
+## 7. Model Changes
+
+### OpenAI Default Model
+
+- 1.x: Previous default
+- 2.x: **`gpt-5-mini`**
+
+### Claude 3 Models Removed
+
+The following Claude 3 models are **no longer available**:
+- `claude-3-opus-*`
+- `claude-3-sonnet-*`
+- `claude-3-haiku-*`
+
+**Migration**: Use Claude 4.x models:
+- `claude-sonnet-4-5-20250929`
+- `claude-opus-4-1-20250805`
+
+### Deprecated Provider Integrations
+
+The following are deprecated and will be removed in a future release:
+- Vertex AI
+- OCI GenAI
+- ZhiPu AI
+
+---
+
+## 8. Anthropic SDK Integration
+
+Spring AI 2.x switches from RestClient-based implementation to the official Anthropic Java SDK. Review custom Anthropic configurations.
+
+---
+
+## 9. Automated Migration (OpenRewrite)
+
+```bash
+mvn org.openrewrite.maven:rewrite-maven-plugin:6.32.0:run \
+  -Drewrite.recipeArtifactCoordinates=org.springframework.ai:spring-ai-rewrite-recipes:2.0.0-M3 \
+  -Drewrite.activeRecipes=org.springframework.ai.migrate.To2_0_0_M3
+```
+
+---
+
+## Migration Checklist
+
+- [ ] Update Spring Boot to 4.0+
+- [ ] Update Spring AI BOM to 2.0.0-M4+
+- [ ] Migrate `FunctionCallback` → `ToolCallback` API
+- [ ] Update MCP annotation imports (`org.springframework.ai.mcp.annotation`)
+- [ ] Update Jackson imports (`tools.jackson`)
+- [ ] Set explicit `temperature` in all ChatOptions
+- [ ] Convert ChatOptions to builder pattern
+- [ ] Replace `disableMemory()` → `disableInternalConversationHistory()`
+- [ ] Update Claude 3 models → Claude 4.x
+- [ ] Review Anthropic SDK integration changes
+- [ ] Run OpenRewrite migration recipe
+- [ ] Verify tool calling behavior with new ToolCallback API
+- [ ] Test structured output with Jackson 3 entity classes

--- a/spring-ai/references/tool-calling.md
+++ b/spring-ai/references/tool-calling.md
@@ -257,6 +257,136 @@ ToolExecutionExceptionProcessor toolErrorProcessor() {
 
 Property: `spring.ai.tools.throw-exception-on-error` (default: `false`)
 
+## MCP Tool Annotations
+
+> Spring AI 2.x integrates MCP (Model Context Protocol) annotations as a core module.
+> Artifact: `org.springframework.ai:spring-ai-mcp-annotations`
+
+### @McpTool
+
+Expose methods as MCP tools. Use in conjunction with or instead of `@Tool` when building MCP servers.
+
+```java
+@Component
+public class MyMcpTools {
+
+    @McpTool(
+        name = "get_customer",
+        description = "Retrieve customer information by ID",
+        annotations = @McpTool.Annotations(
+            readOnlyHint = true,
+            destructiveHint = false,
+            openWorldHint = true
+        )
+    )
+    public String getCustomer(
+        @McpToolParam(description = "Customer ID", required = true) String customerId
+    ) {
+        return customerService.findById(customerId);
+    }
+}
+```
+
+### @McpTool.Annotations Attributes
+
+| Attribute | Default | Description |
+|-----------|---------|-------------|
+| `readOnlyHint` | `false` | Whether the tool is read-only (no side effects) |
+| `destructiveHint` | `true` | Whether the tool may perform destructive operations |
+| `openWorldHint` | `true` | Whether the tool operates in an open world (unknown state space) |
+
+### @McpToolParam
+
+Parameter descriptions for MCP tools — equivalent to `@ToolParam` but for MCP context.
+
+```java
+@McpToolParam(description = "City name for weather lookup", required = false) String city
+```
+
+### @McpProgressToken
+
+Enable progress notifications for long-running MCP tools.
+
+```java
+@McpTool(name = "process_document", description = "Process a large document with progress tracking")
+public String processDocument(
+    @McpToolParam(description = "Document file path") String filePath,
+    McpSyncServerExchange exchange,
+    @McpProgressToken Object progressToken
+) {
+    // Create progress notifier
+    ProgressNotifier notifier = createProgressNotifier(exchange, progressToken);
+
+    for (int i = 0; i < totalPages; i++) {
+        processPage(i);
+        notifier.notify(i + 1, totalPages, "Processing page " + (i + 1));
+    }
+
+    return "Document processed successfully";
+}
+
+private ProgressNotifier createProgressNotifier(McpSyncServerExchange exchange, Object progressToken) {
+    if (progressToken == null) {
+        return (current, total, message) -> {}; // no-op
+    }
+    return (current, total, message) -> exchange.progressNotification(
+        new ProgressNotification(progressToken, (double) current, (double) total, message)
+    );
+}
+
+@FunctionalInterface
+interface ProgressNotifier {
+    void notify(int current, int total, String message);
+}
+```
+
+### MCP Server Dependencies
+
+| Role | Artifact |
+|------|----------|
+| MCP Server (STDIO) | `spring-ai-starter-mcp-server` |
+| MCP Server (WebMVC) | `spring-ai-starter-mcp-server-webmvc` |
+| MCP Server (WebFlux) | `spring-ai-starter-mcp-server-webflux` |
+| MCP Client | `spring-ai-starter-mcp-client` |
+| MCP Annotations only | `spring-ai-mcp-annotations` |
+
+### MCP Server Configuration
+
+```yaml
+spring:
+  ai:
+    mcp:
+      server:
+        name: my-mcp-server
+        version: 1.0.0
+        type: SYNC        # SYNC or ASYNC
+        protocol: STDIO   # STDIO, SSE, or STREAMABLE
+```
+
+### MCP Client Customization (2.x)
+
+```java
+@Configuration
+class McpClientConfig {
+    @Bean
+    McpClientCustomizer<McpAsyncClient.Builder> mcpClientCustomizer() {
+        return builder -> builder
+            .toolCallbacks(additionalToolCallbacks)
+            // Customize client behavior
+            .build();
+    }
+}
+```
+
+### MCP Tool Annotations Rules
+
+- Use `@McpTool` for tools exposed via MCP server — not for internal tool calling
+- `@Tool` and `@McpTool` serve different purposes: `@Tool` for ChatClient tool calling, `@McpTool` for MCP server tool exposure
+- Always provide meaningful `description` — MCP clients use it for tool discovery
+- Use `@McpTool.Annotations` hints to help MCP clients optimize tool usage
+- `@McpProgressToken` requires `McpSyncServerExchange` parameter in the method signature
+- Progress notifications are optional — guard against null `progressToken`
+
 ## Key Interfaces
 
 ### ToolDefinition

--- a/spring-ai/references/tool-calling.md
+++ b/spring-ai/references/tool-calling.md
@@ -371,9 +371,7 @@ class McpClientConfig {
     @Bean
     McpClientCustomizer<McpAsyncClient.Builder> mcpClientCustomizer() {
         return builder -> builder
-            .capabilities(/* configure capabilities */)
             .requestTimeout(Duration.ofSeconds(30));
-            // Customize client behavior
     }
 }
 ```

--- a/spring-ai/references/tool-calling.md
+++ b/spring-ai/references/tool-calling.md
@@ -276,7 +276,7 @@ public class MyMcpTools {
     @McpTool(
         name = "get_customer",
         description = "Retrieve customer information by ID",
-        annotations = @McpTool.Annotations(
+        annotations = @McpTool.McpAnnotations(
             readOnlyHint = true,
             destructiveHint = false,
             openWorldHint = true
@@ -290,12 +290,13 @@ public class MyMcpTools {
 }
 ```
 
-### @McpTool.Annotations Attributes
+### @McpTool.McpAnnotations Attributes
 
 | Attribute | Default | Description |
 |-----------|---------|-------------|
 | `readOnlyHint` | `false` | Whether the tool is read-only (no side effects) |
 | `destructiveHint` | `true` | Whether the tool may perform destructive operations |
+| `idempotentHint` | `true` | Whether calling the tool twice has the same effect as calling once |
 | `openWorldHint` | `true` | Whether the tool operates in an open world (unknown state space) |
 
 ### @McpToolParam
@@ -386,7 +387,7 @@ class McpClientConfig {
 - Use `@McpTool` for tools exposed via MCP server — not for internal tool calling
 - `@Tool` and `@McpTool` serve different purposes: `@Tool` for ChatClient tool calling, `@McpTool` for MCP server tool exposure
 - Always provide meaningful `description` — MCP clients use it for tool discovery
-- Use `@McpTool.Annotations` hints to help MCP clients optimize tool usage
+- Use `@McpTool.McpAnnotations` hints to help MCP clients optimize tool usage
 - `@McpProgressToken` requires `McpSyncServerExchange` parameter in the method signature
 - Progress notifications are optional — guard against null `progressToken`
 

--- a/spring-ai/references/tool-calling.md
+++ b/spring-ai/references/tool-calling.md
@@ -371,9 +371,9 @@ class McpClientConfig {
     @Bean
     McpClientCustomizer<McpAsyncClient.Builder> mcpClientCustomizer() {
         return builder -> builder
-            .toolCallbacks(additionalToolCallbacks)
+            .capabilities(/* configure capabilities */)
+            .requestTimeout(Duration.ofSeconds(30));
             // Customize client behavior
-            .build();
     }
 }
 ```

--- a/spring-ai/references/tool-calling.md
+++ b/spring-ai/references/tool-calling.md
@@ -180,6 +180,7 @@ chatClient.prompt()
 ### Advisor-Controlled
 
 ```java
+// ToolCallingManager is auto-configured by Spring Boot
 var toolCallAdvisor = ToolCallAdvisor.builder()
     .toolCallingManager(toolCallingManager)
     .advisorOrder(BaseAdvisor.HIGHEST_PRECEDENCE + 300)
@@ -193,6 +194,8 @@ ChatClient chatClient = ChatClient.builder(chatModel)
 ### User-Controlled (Manual Loop)
 
 ```java
+// toolCallbacks: obtain via ToolCallbacks.from(new MyTools())
+// toolCallingManager: auto-configured by Spring Boot
 ToolCallingChatOptions options = ToolCallingChatOptions.builder()
     .toolCallbacks(toolCallbacks)
     .internalToolExecutionEnabled(false)
@@ -369,12 +372,14 @@ spring:
 @Configuration
 class McpClientConfig {
     @Bean
-    McpClientCustomizer<McpAsyncClient.Builder> mcpClientCustomizer() {
+    McpClientCustomizer<?> mcpClientCustomizer() {
         return builder -> builder
             .requestTimeout(Duration.ofSeconds(30));
     }
 }
 ```
+
+> `McpClientCustomizer` auto-configures MCP clients. The type parameter matches the client builder type (sync or async).
 
 ### MCP Tool Annotations Rules
 

--- a/spring-ai/references/vector-store-rag.md
+++ b/spring-ai/references/vector-store-rag.md
@@ -277,7 +277,7 @@ String answer = chatClient.prompt()
 Advisor ragAdvisor = RetrievalAugmentationAdvisor.builder()
     .queryTransformers(
         RewriteQueryTransformer.builder()
-            .chatClientBuilder(chatClientBuilder.build().mutate())
+            .chatClientBuilder(chatClientBuilder)
             .build())
     .documentRetriever(VectorStoreDocumentRetriever.builder()
         .vectorStore(vectorStore)
@@ -285,6 +285,8 @@ Advisor ragAdvisor = RetrievalAugmentationAdvisor.builder()
         .build())
     .build();
 ```
+
+> Inject `ChatClient.Builder chatClientBuilder` via Spring DI. Do not call `.build().mutate()` — pass the builder directly.
 
 #### Allow Empty Context
 
@@ -333,6 +335,7 @@ DocumentRetriever retriever = VectorStoreDocumentRetriever.builder()
 Compresses conversation history into a standalone query.
 
 ```java
+// Inject ChatClient.Builder via Spring DI
 QueryTransformer transformer = CompressionQueryTransformer.builder()
     .chatClientBuilder(chatClientBuilder)
     .build();
@@ -370,6 +373,8 @@ MultiQueryExpander expander = MultiQueryExpander.builder()
     .includeOriginal(true)
     .build();
 ```
+
+> All transformers accept `ChatClient.Builder` — inject it via Spring DI. Do not pre-build the `ChatClient`.
 
 ## Query Augmentation
 

--- a/spring-ai/references/vector-store-rag.md
+++ b/spring-ai/references/vector-store-rag.md
@@ -120,25 +120,25 @@ Expression exp = b.isNotNull("category").build();
 
 ## Supported Vector Databases
 
-| Database             | Artifact                        |
-| -------------------- | ------------------------------- |
-| Azure Vector Search  | `spring-ai-azure-store`         |
-| Apache Cassandra     | `spring-ai-cassandra-store`     |
-| Chroma               | `spring-ai-chroma-store`        |
-| Elasticsearch        | `spring-ai-elasticsearch-store` |
-| Milvus               | `spring-ai-milvus-store`        |
-| MongoDB Atlas        | `spring-ai-mongodb-atlas-store` |
-| Neo4j                | `spring-ai-neo4j-store`         |
-| OpenSearch           | `spring-ai-opensearch-store`    |
-| PGVector (PostgreSQL)| `spring-ai-pgvector-store`      |
-| Pinecone             | `spring-ai-pinecone-store`      |
-| Qdrant               | `spring-ai-qdrant-store`        |
-| Redis                | `spring-ai-redis-store`         |
-| Amazon Bedrock Knowledge Base | `spring-ai-bedrock-kb-store` |
-| Amazon S3 | `spring-ai-amazon-s3-store` |
-| Infinispan | `spring-ai-infinispan-store` |
-| Weaviate             | `spring-ai-weaviate-store`      |
-| SimpleVectorStore    | `spring-ai-core` (in-memory)    |
+| Database                       | Artifact                            |
+| ------------------------------ | ----------------------------------- |
+| Amazon Bedrock Knowledge Base  | `spring-ai-bedrock-kb-store`        |
+| Amazon S3                      | `spring-ai-amazon-s3-store`         |
+| Apache Cassandra               | `spring-ai-cassandra-store`         |
+| Azure Vector Search            | `spring-ai-azure-store`             |
+| Chroma                         | `spring-ai-chroma-store`            |
+| Elasticsearch                  | `spring-ai-elasticsearch-store`     |
+| Infinispan                     | `spring-ai-infinispan-store`        |
+| Milvus                         | `spring-ai-milvus-store`            |
+| MongoDB Atlas                  | `spring-ai-mongodb-atlas-store`     |
+| Neo4j                          | `spring-ai-neo4j-store`             |
+| OpenSearch                     | `spring-ai-opensearch-store`        |
+| PGVector (PostgreSQL)          | `spring-ai-pgvector-store`          |
+| Pinecone                       | `spring-ai-pinecone-store`          |
+| Qdrant                         | `spring-ai-qdrant-store`            |
+| Redis                          | `spring-ai-redis-store`             |
+| Weaviate                       | `spring-ai-weaviate-store`          |
+| SimpleVectorStore              | `spring-ai-core` (in-memory)        |
 
 ## Batching Strategy
 

--- a/spring-ai/references/vector-store-rag.md
+++ b/spring-ai/references/vector-store-rag.md
@@ -66,7 +66,11 @@ vectorStore.delete(filter);
 vectorStore.delete("country == 'Korea'");
 ```
 
+Enhanced `IN` and `NIN` (not-in) filter expression grouping is available in 2.x.
+
 ## Metadata Filtering
+
+Spring AI 2.x adds JSpecify `@NonNull`/`@Nullable` annotations to most vector store implementations for compile-time null safety.
 
 ### String Syntax (SQL-like)
 
@@ -102,6 +106,18 @@ Expression exp = b.isNull("year").build();
 Expression exp = b.isNotNull("year").build();
 ```
 
+### Null Value Filters (2.x)
+
+Spring AI 2.x adds `ISNULL` and `ISNOTNULL` filter expressions:
+
+```java
+// ISNULL filter
+Expression exp = b.isNull("category").build();
+
+// ISNOTNULL filter
+Expression exp = b.isNotNull("category").build();
+```
+
 ## Supported Vector Databases
 
 | Database             | Artifact                        |
@@ -118,6 +134,9 @@ Expression exp = b.isNotNull("year").build();
 | Pinecone             | `spring-ai-pinecone-store`      |
 | Qdrant               | `spring-ai-qdrant-store`        |
 | Redis                | `spring-ai-redis-store`         |
+| Amazon Bedrock Knowledge Base | `spring-ai-bedrock-kb-store` |
+| Amazon S3 | `spring-ai-amazon-s3-store` |
+| Infinispan | `spring-ai-infinispan-store` |
 | Weaviate             | `spring-ai-weaviate-store`      |
 | SimpleVectorStore    | `spring-ai-core` (in-memory)    |
 


### PR DESCRIPTION
## Summary

- Spring AI 2.x (2.0.0-M4) + Spring Boot 4.0 대응 스킬 업데이트
- MCP Tool Annotations 섹션 신규 추가 (`@McpTool`, `@McpToolParam`, `@McpProgressToken`)
- Spring AI 1.x → 2.x 마이그레이션 가이드 신규 작성
- Jackson 3, ChatOptions 빌더 패턴, temperature 기본값 제거 등 2.x 변경사항 반영

## Changes

### `SKILL.md`
- Platform Requirements 섹션 추가 (Boot 4.0+, JDK 17+, Jackson 3)
- 명시적 temperature 설정 규칙, `disableInternalConversationHistory()` 마이그레이션 안내
- 모델명 업데이트: `gpt-5-mini`, `claude-sonnet-4-5-20250929`
- Anti-patterns 추가: setter-style ChatOptions, 기본 temperature 의존

### `references/chatclient-patterns.md`
- Native Structured Output 섹션 (`AdvisorParams.ENABLE_NATIVE_STRUCTURED_OUTPUT`)
- Spring Boot 4.0 HTTP Client Integration (`HttpClientSettings`, `ClientHttpRequestFactoryBuilder`)
- Jackson 3, no default temperature, builder-only ChatOptions 안내

### `references/tool-calling.md`
- **MCP Tool Annotations 섹션 신규** (~130 lines)
  - `@McpTool`, `@McpTool.Annotations` (readOnlyHint, destructiveHint, openWorldHint)
  - `@McpToolParam`, `@McpProgressToken` with Progress Notification pattern
  - MCP Server Dependencies table, configuration, client customization

### `references/vector-store-rag.md`
- 신규 벡터 스토어: Amazon S3, Infinispan, Amazon Bedrock Knowledge Base
- `ISNULL`/`ISNOTNULL` 필터, JSpecify null safety 안내

### `references/advanced-rag-agents.md`
- Redis `ChatMemoryRepository` 패턴
- Google `ThinkingLevel` 설정

### `references/migration-2x.md` (신규)
- FunctionCallback → ToolCallback API 매핑 테이블
- MCP 어노테이션 패키지 재배치 안내
- Jackson 2 → Jackson 3 마이그레이션
- OpenRewrite 자동화 레시피
- 마이그레이션 체크리스트

### `README.md`
- 디렉토리 구조에 `migration-2x.md` 추가